### PR TITLE
feat: use new generic filters

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,89 @@
+env:
+  node: true
+  es6: true
+
+parserOptions:
+  ecmaVersion: 2018
+
+rules:
+  # Ignore Rules
+  strict: 0
+  no-underscore-dangle: 0
+  no-mixed-requires: 0
+  no-process-exit: 0
+  no-warning-comments: 0
+  curly: 0
+  no-multi-spaces: 0
+  no-alert: 0
+  consistent-return: 0
+  consistent-this: [0, self]
+  func-style: 0
+  max-nested-callbacks: 0
+
+  # Warnings
+  no-debugger: 1
+  no-empty: 1
+  no-invalid-regexp: 1
+  no-unused-expressions: 1
+  no-native-reassign: 1
+  no-fallthrough: 1
+  camelcase: 0
+
+  # Errors
+  eqeqeq: 2
+  no-undef: 2
+  no-dupe-keys: 2
+  no-empty-character-class: 2
+  no-self-compare: 2
+  valid-typeof: 2
+  no-unused-vars: [2, { "args": "none" }]
+  handle-callback-err: 2
+  no-shadow-restricted-names: 2
+  no-new-require: 2
+  no-mixed-spaces-and-tabs: 2
+  block-scoped-var: 2
+  no-else-return: 2
+  no-throw-literal: 2
+  no-void: 2
+  radix: 2
+  wrap-iife: [2, outside]
+  no-shadow: 0
+  no-use-before-define: [2, nofunc]
+  no-path-concat: 2
+  valid-jsdoc: [0, {requireReturn: false, requireParamDescription: false, requireReturnDescription: false}]
+
+  # stylistic errors
+  no-spaced-func: 2
+  semi-spacing: 2
+  quotes: [2, 'single']
+  key-spacing: [2, { beforeColon: false, afterColon: true }]
+  indent: [2, 2]
+  no-lonely-if: 2
+  no-floating-decimal: 2
+  brace-style: [2, 1tbs, { allowSingleLine: true }]
+  comma-style: [2, last]
+  no-multiple-empty-lines: [2, {max: 1}]
+  no-nested-ternary: 2
+  operator-assignment: [2, always]
+  padded-blocks: [2, never]
+  quote-props: [2, as-needed]
+  keyword-spacing: [2, {'before': true, 'after': true, 'overrides': {}}]
+  space-before-blocks: [2, always]
+  array-bracket-spacing: [2, never]
+  computed-property-spacing: [2, never]
+  space-in-parens: [2, never]
+  space-unary-ops: [2, {words: true, nonwords: false}]
+  wrap-regex: 2
+  linebreak-style: [2, unix]
+  semi: [2, always]
+  arrow-spacing: [2, {before: true, after: true}]
+  no-class-assign: 2
+  no-const-assign: 2
+  no-dupe-class-members: 2
+  no-this-before-super: 2
+  no-var: 2
+  object-shorthand: [2, always]
+  prefer-arrow-callback: 2
+  prefer-const: 2
+  prefer-spread: 2
+  prefer-template: 2

--- a/.tp-config.json
+++ b/.tp-config.json
@@ -68,5 +68,8 @@
       "description": "The type of artifact that will be generated, either library or application.",
       "required": false
     }
-  }
+  },
+  "filters": [
+    "@asyncapi/generator-filters"
+  ]
 }

--- a/filters/all.js
+++ b/filters/all.js
@@ -283,10 +283,10 @@ function fixType([name, javaName, property]) {
 }
 filter.fixType = fixType;
 
-function functions([asyncapi, params]) {
+function functionSpecs([asyncapi, params]) {
   return getFunctionSpecs(asyncapi, params);
 }
-filter.functions = functions;
+filter.functionSpecs = functionSpecs;
 
 function groupId([info, params]) {  
   return scsLib.getParamOrDefault(info, params, 'groupId', 'x-group-id', 'com.company');
@@ -473,7 +473,8 @@ function getBindings(asyncapi, params) {
 // This returns the base function name that SCSt will use to map functions with bindings.
 function getFunctionName(channelName, operation) {
   let ret;
-  //console.log('functionName operation: ' + JSON.stringify(operation));
+  //console.log('getFunctionName operation: ' + JSON.stringify(operation));
+  //console.log(operation);
   let functionName = operation.ext('x-scs-function-name');
   //console.log(getMethods(operation));
 

--- a/filters/all.js
+++ b/filters/all.js
@@ -1,704 +1,711 @@
 // vim: set ts=2 sw=2 sts=2 expandtab :
-module.exports = ({ Nunjucks }) => {
-
-  var yaml = require('js-yaml');
-  var _ = require('lodash');
-  const ScsLib = require('../lib/ScsLib');
-	const scsLib = new ScsLib();
+const filter = module.exports;
+const yaml = require('js-yaml');
+const _ = require('lodash');
+const ScsLib = require('../lib/ScsLib');
+const scsLib = new ScsLib();
 	
-	// Library versions
-	const SOLACE_SPRING_CLOUD_VERSION = '1.0.0';
-	const SPRING_BOOT_VERSION = '2.2.6.RELEASE';
-	const SPRING_CLOUD_VERSION = 'Hoxton.SR3';
-	const SPRING_CLOUD_STREAM_VERSION = '3.0.3.RELEASE';
+// Library versions
+const SOLACE_SPRING_CLOUD_VERSION = '1.0.0';
+const SPRING_BOOT_VERSION = '2.2.6.RELEASE';
+const SPRING_CLOUD_VERSION = 'Hoxton.SR3';
+const SPRING_CLOUD_STREAM_VERSION = '3.0.3.RELEASE';
 
-	// Connection defaults. SOLACE_DEFAULT applies to msgVpn, username and password.
-	const SOLACE_HOST = 'tcp://localhost:55555';
-	const SOLACE_DEFAULT = 'default';
+// Connection defaults. SOLACE_DEFAULT applies to msgVpn, username and password.
+const SOLACE_HOST = 'tcp://localhost:55555';
+const SOLACE_DEFAULT = 'default';
 
-  // This maps json schema types to Java format strings.
-  const formatMap = new Map();
-  formatMap.set('boolean', '%s');
-  formatMap.set('enum', '%s');
-  formatMap.set('integer', '%d');
-  formatMap.set('number', '%f');
-  formatMap.set('null', '%s');
-  formatMap.set('string', '%s');
+// This maps json schema types to Java format strings.
+const formatMap = new Map();
+formatMap.set('boolean', '%s');
+formatMap.set('enum', '%s');
+formatMap.set('integer', '%d');
+formatMap.set('number', '%f');
+formatMap.set('null', '%s');
+formatMap.set('string', '%s');
 
-  // This maps json schema types to examples of values.
-  const sampleMap = new Map();
-  sampleMap.set('boolean', 'true');
-  sampleMap.set('integer', '1');
-  sampleMap.set('null', 'string');
-  sampleMap.set('number', '1.1');
-  sampleMap.set('string', '"string"');
+// This maps json schema types to examples of values.
+const sampleMap = new Map();
+sampleMap.set('boolean', 'true');
+sampleMap.set('integer', '1');
+sampleMap.set('null', 'string');
+sampleMap.set('number', '1.1');
+sampleMap.set('string', '"string"');
 
-  // This maps json schema types to Java types.
-  const typeMap = new Map();
-  typeMap.set('boolean', 'Boolean');
-  typeMap.set('integer', 'Integer');
-  typeMap.set('null', 'String');
-  typeMap.set('number', 'Double');
-  typeMap.set('string', 'String');
-	
-  class SCSFunction {
-    name;
-    type;
-    group;
-    publishChannel;
-    subscribeChannel;
-    publishPayload;
-    subscribePayload;
-    reactive;
+// This maps json schema types to Java types.
+const typeMap = new Map();
+typeMap.set('boolean', 'Boolean');
+typeMap.set('integer', 'Integer');
+typeMap.set('null', 'String');
+typeMap.set('number', 'Double');
+typeMap.set('string', 'String');
 
-    get publishBindingName() {
-      return this.name + "-out-0";
-    }
+class SCSFunction {
+  name;
+  type;
+  group;
+  publishChannel;
+  subscribeChannel;
+  publishPayload;
+  subscribePayload;
+  reactive;
 
-    get subscribeBindingName() {
-      return this.name + "-in-0";
-    }
-
-    get functionSignature() {
-      var ret = '';
-      switch(this.type) {
-        case 'function':
-          if (this.reactive) {
-            ret = `public Function<Flux<${this.subscribePayload}>, Flux<${this.publishPayload}>> ${this.name}()`;
-          } else {
-            ret = `public Function<${this.subscribePayload}, ${this.publishPayload}> ${this.name}()`;
-          }
-          break;
-        case 'supplier':
-          if (this.reactive) {
-            ret = `public Supplier<Flux<${this.publishPayload}>> ${this.name}()`;
-          } else {
-            ret = `public Supplier<${this.publishPayload}> ${this.name}()`;
-          }
-          break;
-        case 'consumer':
-          if (this.reactive) {
-            ret = `public Consumer<Flux<${this.subscribePayload}>> ${this.name}()`;
-          } else {
-            ret = `public Consumer<${this.subscribePayload}> ${this.name}()`;
-          }
-          break;
-        default:
-          throw new Error(`Can't determine the function signature for ${this.name} because the type is ${this.type}`);
-      }
-      return ret;
-    }
-
-    get isPublisher() {
-      return this.type === 'function' || this.type === 'supplier';
-    }
-
-    get isSubscriber() {
-      return this.type === 'function' || this.type === 'consumer';
-    }
-
+  get publishBindingName() {
+    return this.name + "-out-0";
   }
 
-  // This generates the object that gets rendered in the application.yaml file.
-  Nunjucks.addFilter('appProperties', ([asyncapi, params]) => {
-    params.binder = params.binder || 'kafka';
-    if (params.binder != 'kafka' && params.binder != 'rabbit' && params.binder != 'solace') {
-      throw new Error("Please provide a parameter named 'binder' with the value kafka, rabbit or solace.");
+  get subscribeBindingName() {
+    return this.name + "-in-0";
+  }
+
+  get functionSignature() {
+    var ret = '';
+    switch(this.type) {
+      case 'function':
+        if (this.reactive) {
+          ret = `public Function<Flux<${this.subscribePayload}>, Flux<${this.publishPayload}>> ${this.name}()`;
+        } else {
+          ret = `public Function<${this.subscribePayload}, ${this.publishPayload}> ${this.name}()`;
+        }
+        break;
+      case 'supplier':
+        if (this.reactive) {
+          ret = `public Supplier<Flux<${this.publishPayload}>> ${this.name}()`;
+        } else {
+          ret = `public Supplier<${this.publishPayload}> ${this.name}()`;
+        }
+        break;
+      case 'consumer':
+        if (this.reactive) {
+          ret = `public Consumer<Flux<${this.subscribePayload}>> ${this.name}()`;
+        } else {
+          ret = `public Consumer<${this.subscribePayload}> ${this.name}()`;
+        }
+        break;
+      default:
+        throw new Error(`Can't determine the function signature for ${this.name} because the type is ${this.type}`);
     }
+    return ret;
+  }
 
-    let doc = {};
-    doc.spring = {};
-    doc.spring.cloud = {};
-    doc.spring.cloud.stream = {};
-    let scs = doc.spring.cloud.stream;
-    scs.function = {};
-    scs.function.definition = getFunctionDefinitions(asyncapi, params);
-    scs.bindings = getBindings(asyncapi, params);
+  get isPublisher() {
+    return this.type === 'function' || this.type === 'supplier';
+  }
 
+  get isSubscriber() {
+    return this.type === 'function' || this.type === 'consumer';
+  }
+
+}
+
+// This generates the object that gets rendered in the application.yaml file.
+function appProperties([asyncapi, params]) {
+  params.binder = params.binder || 'kafka';
+  if (params.binder != 'kafka' && params.binder != 'rabbit' && params.binder != 'solace') {
+    throw new Error("Please provide a parameter named 'binder' with the value kafka, rabbit or solace.");
+  }
+
+  let doc = {};
+  doc.spring = {};
+  doc.spring.cloud = {};
+  doc.spring.cloud.stream = {};
+  let scs = doc.spring.cloud.stream;
+  scs.function = {};
+  scs.function.definition = getFunctionDefinitions(asyncapi, params);
+  scs.bindings = getBindings(asyncapi, params);
+
+  if (params.binder === 'solace') {
+    let additionalSubs = getAdditionalSubs(asyncapi);
+
+    if (additionalSubs) {
+      scs.solace = additionalSubs;
+    }
+  }
+
+  if (isApplication(params)) {
     if (params.binder === 'solace') {
-      let additionalSubs = getAdditionalSubs(asyncapi);
-
-      if (additionalSubs) {
-        scs.solace = additionalSubs;
-      }
+      doc.solace = getSolace(params);
     }
 
-		if (isApplication(params)) {
-      if (params.binder === 'solace') {
-        doc.solace = getSolace(params);
-      }
+    doc.logging = {};
+    doc.logging.level = {};
+    doc.logging.level.root = 'info';
+    doc.logging.level.org = {};
+    doc.logging.level.org.springframework = 'info';
 
-      doc.logging = {};
-      doc.logging.level = {};
-      doc.logging.level.root = 'info';
-      doc.logging.level.org = {};
-      doc.logging.level.org.springframework = 'info';
-
-      if (params.actuator === 'true') {
-        doc.server = {};
-        doc.server.port = 8080;
-        doc.management = {};
-        doc.management.endpoints = {};
-        doc.management.endpoints.web = {};
-        doc.management.endpoints.web.exposure = {};
-        doc.management.endpoints.web.exposure.include = '*';
-      }
+    if (params.actuator === 'true') {
+      doc.server = {};
+      doc.server.port = 8080;
+      doc.management = {};
+      doc.management.endpoints = {};
+      doc.management.endpoints.web = {};
+      doc.management.endpoints.web.exposure = {};
+      doc.management.endpoints.web.exposure.include = '*';
     }
-    let ym = yaml.safeDump(doc, { lineWidth: 200 } );
-    //console.log(ym);
-    return ym;
-  });
+  }
+  let ym = yaml.safeDump(doc, { lineWidth: 200 } );
+  //console.log(ym);
+  return ym;
+};
+filter.appProperties = appProperties;
 
-  Nunjucks.addFilter('artifactId', ([info, params]) => {
-    return scsLib.getParamOrDefault(info, params, 'artifactId', 'x-artifact-id', 'project-name');
-  })
+function artifactId([info, params]) {
+  return scsLib.getParamOrDefault(info, params, 'artifactId', 'x-artifact-id', 'project-name');
+}
+filter.artifactId = artifactId;
 
-  Nunjucks.addFilter('appExtraIncludes', (asyncapi) => {
-    let ret = {};
-    
-    for (let channelName in asyncapi.channels()) {
-      let channel = asyncapi.channels()[channelName];
-      let subscribe = channel.subscribe();
-      
-      if (subscribe && subscribe.hasMultipleMessages()) {
-        ret.hasMultipleMessages = true;
-        break;
-      }
-
-      let publish = channel.publish();
-      if (publish && publish.hasMultipleMessages()) {
-        ret.hasMultipleMessages = true;
-        break;
-      }
-    }
+function appExtraIncludes(asyncapi) {
+  let ret = {};
   
-    return ret;
-  })
-
-  Nunjucks.addFilter('camelCase', (str) => {
-    return _.camelCase(str);
-  })
-
-  Nunjucks.addFilter('schemaExtraIncludes', ([schemaName, schema]) => {
-    //console.log("checkPropertyNames " + schemaName + "  " + schema.type());
-    let ret = {};
-    if(checkPropertyNames(schemaName, schema)) {
-      ret.jsonProperty = true;
+  for (let channelName in asyncapi.channels()) {
+    let channel = asyncapi.channels()[channelName];
+    let subscribe = channel.subscribe();
+    
+    if (subscribe && subscribe.hasMultipleMessages()) {
+      ret.hasMultipleMessages = true;
+      break;
     }
-//    console.log("checkPropertyNames:");
-//    console.log(ret);
-    return ret;
-  })
 
-  // This determines the base function name that we will use for the SCSt mapping between functions and bindings.
-  Nunjucks.addFilter('functionName', ([channelName, channel]) => {
-    return getFunctionNameByChannel(channelName, channel);
-  })
+    let publish = channel.publish();
+    if (publish && publish.hasMultipleMessages()) {
+      ret.hasMultipleMessages = true;
+      break;
+    }
+  }
 
-  Nunjucks.addFilter('identifierName', (str) => {
-    return scsLib.getIdentifierName(str);
-  })
+  return ret;
+}
+filter.appExtraIncludes = appExtraIncludes;
 
-  Nunjucks.addFilter('indent1', (numTabs) => {
-    return indent(numTabs);
-  })
+function schemaExtraIncludes([schemaName, schema]) {
 
-  Nunjucks.addFilter('indent2', (numTabs) => {
-    return indent(numTabs + 1);
-  })
+  //console.log("checkPropertyNames " + schemaName + "  " + schema.type());
+  let ret = {};
+  if(checkPropertyNames(schemaName, schema)) {
+    ret.jsonProperty = true;
+  }
+  //console.log("checkPropertyNames:");
+  //console.log(ret);
+  return ret;
+}
+filter.schemaExtraIncludes = schemaExtraIncludes;
 
-  Nunjucks.addFilter('indent3', (numTabs) => {
-    return indent(numTabs + 2);
-  })
+// This determines the base function name that we will use for the SCSt mapping between functions and bindings.
+function functionName([channelName, channel]) {
+
+  return getFunctionNameByChannel(channelName, channel);
+}
+filter.functionName = functionName;
+
+function identifierName(str) {
+  return scsLib.getIdentifierName(str);
+}
+filter.identifierName = identifierName;
+
+function indent1(numTabs) {
+  return indent(numTabs);
+}
+filter.indent1 = indent1;
+
+function indent2(numTabs) {
+  return indent(numTabs + 1);
+}
+filter.indent2 = indent2;
+
+function indent3(numTabs) {
+  return indent(numTabs + 2);
+}
+filter.indent3 = indent3;
 
   // This returns the proper Java type for a schema property.
-  Nunjucks.addFilter('fixType', ([name, javaName, property]) => {
+function fixType([name, javaName, property]) {
 
-    //console.log('fixType: ' + name + " " + dump(property));
-    
-    let isArrayOfObjects = false;
+  //console.log('fixType: ' + name + " " + dump(property));
+  
+  let isArrayOfObjects = false;
 
-    // For message headers, type is a property.
-    // For schema properties, type is a function.
-    let type = property.type;
+  // For message headers, type is a property.
+  // For schema properties, type is a function.
+  let type = property.type;
 
-    //console.log("fixType: " + property);
+  //console.log("fixType: " + property);
 
-    if (typeof type == "function") {
-      type = property.type();
-    }
+  if (typeof type == "function") {
+    type = property.type();
+  }
 
-    // If a schema has a property that is a ref to another schema,
-    // the type is undefined, and the title gives the title of the referenced schema.
-    let ret;
-    if (type === undefined) {
-      if (property.enum()) {
-        ret = _.upperFirst(javaName);
-      } else {
-        // check to see if it's a ref to another schema.
-        ret = property.ext('x-parser-schema-id');
-
-        if (!ret) {
-          throw new Error("Can't determine the type of property " + name);
-        }
-      }
-    } else if (type === 'array') {
-      if (!property.items()) {
-        throw new Error("Array named " + name + " must have an 'items' property to indicate what type the array elements are.");
-      }
-      let itemsType = property.items().type();
-
-      if (itemsType) {
-
-        if (itemsType === 'object') {
-          isArrayOfObjects = true;
-          itemsType = _.upperFirst(javaName);
-        } else {
-          itemsType = typeMap.get(itemsType);
-        }
-      }
-      if (!itemsType) {
-        itemsType = property.items().ext('x-parser-schema-id');
-        //console.log("items: " + itemsType + " -- " + itemsType2);
-
-        if (!itemsType) {
-          throw new Error("Array named " + name + ": can't determine the type of the items.");
-        }
-      }
-      ret = _.upperFirst(itemsType) + "[]";
-    } else if (type === 'object') {
+  // If a schema has a property that is a ref to another schema,
+  // the type is undefined, and the title gives the title of the referenced schema.
+  let ret;
+  if (type === undefined) {
+    if (property.enum()) {
       ret = _.upperFirst(javaName);
     } else {
-      ret = typeMap.get(type);
+      // check to see if it's a ref to another schema.
+      ret = property.ext('x-parser-schema-id');
+
       if (!ret) {
-        ret = type;
+        throw new Error("Can't determine the type of property " + name);
       }
     }
-    return [ret, isArrayOfObjects];
-  })
-
-  Nunjucks.addFilter('functions', ([asyncapi, params]) => {
-    return getFunctionSpecs(asyncapi, params);
-  });
-
-  Nunjucks.addFilter('groupId', ([info, params]) => {
-    return scsLib.getParamOrDefault(info, params, 'groupId', 'x-group-id', 'com.company');
-  })
-
-  Nunjucks.addFilter('log', (str) => {
-    console.log(str);
-    return str;
-  })
-
-  Nunjucks.addFilter('logFull', (obj) => {
-    console.log(obj);
-    if (obj) {
-      console.log(dump(obj));
-      console.log(getMethods(obj));
+  } else if (type === 'array') {
+    if (!property.items()) {
+      throw new Error("Array named " + name + " must have an 'items' property to indicate what type the array elements are.");
     }
-    return obj;
-  })
+    let itemsType = property.items().type();
 
+    if (itemsType) {
 
-  Nunjucks.addFilter('lowerFirst', (str) => {
-    return _.lowerFirst(str);
-  })
+      if (itemsType === 'object') {
+        isArrayOfObjects = true;
+        itemsType = _.upperFirst(javaName);
+      } else {
+        itemsType = typeMap.get(itemsType);
+      }
+    }
+    if (!itemsType) {
+      itemsType = property.items().ext('x-parser-schema-id');
 
-  Nunjucks.addFilter('mainClassName', ([info, params]) => {
-    return scsLib.getParamOrDefault(info, params, 'javaClass', 'x-java-class', 'Application');
-  });
-
-  // This returns the Java class name of the payload.
-  Nunjucks.addFilter('payloadClass', ([channelName, channel]) => {
-    let ret = getPayloadClass(channel.publish());
+      if (!itemsType) {
+        throw new Error("Array named " + name + ": can't determine the type of the items.");
+      }
+    }
+    ret = _.upperFirst(itemsType) + "[]";
+  } else if (type === 'object') {
+    ret = _.upperFirst(javaName);
+  } else {
+    ret = typeMap.get(type);
     if (!ret) {
-      ret = getPayloadClass(channel.subscribe());
+      ret = type;
     }
-    if (!ret) {
-      throw new Error("Channel " + channelName + ": no payload class has been defined.");
+  }
+  return [ret, isArrayOfObjects];
+}
+filter.fixType = fixType;
+
+function functions([asyncapi, params]) {
+  return getFunctionSpecs(asyncapi, params);
+}
+filter.functions = functions;
+
+function groupId([info, params]) {  
+  return scsLib.getParamOrDefault(info, params, 'groupId', 'x-group-id', 'com.company');
+}
+filter.groupId = groupId;
+
+function logFull(obj) {
+  console.log(obj);
+  if (obj) {
+    console.log(dump(obj));
+    console.log(getMethods(obj));
+  }
+  return obj;
+}
+filter.logFull = logFull;
+
+function lowerFirst(str) {
+  return _.lowerFirst(str);
+}
+filter.lowerFirst = lowerFirst;
+
+function mainClassName([info, params]) {
+  return scsLib.getParamOrDefault(info, params, 'javaClass', 'x-java-class', 'Application');
+};
+filter.mainClassName = mainClassName;
+
+// This returns the Java class name of the payload.
+function payloadClass([channelName, channel]) {
+  let ret = getPayloadClass(channel.publish());
+  if (!ret) {
+    ret = getPayloadClass(channel.subscribe());
+  }
+  if (!ret) {
+    throw new Error("Channel " + channelName + ": no payload class has been defined.");
+  }
+  return ret;
+}
+filter.payloadClass = payloadClass;
+
+function solaceSpringCloudVersion([info, params]) {
+
+  var required = isApplication(params) && params.binder === 'solace';
+  return scsLib.getParamOrDefault(info, params, 'solaceSpringCloudVersion', 'x-solace-spring-cloud-version', SOLACE_SPRING_CLOUD_VERSION);
+}
+filter.solaceSpringCloudVersion = solaceSpringCloudVersion;
+
+function springBootVersion([info, params]) {
+  return scsLib.getParamOrDefault(info, params, 'springBootVersion', 'x-spring-boot-version', SPRING_BOOT_VERSION);
+}
+filter.springBootVersion = springBootVersion;
+
+function springCloudStreamVersion([info, params]) {
+  return scsLib.getParamOrDefault(info, params, 'springCloudStreamVersion', 'x-spring-cloud-stream-version', SPRING_CLOUD_STREAM_VERSION);
+}
+filter.springCloudStreamVersion = springCloudStreamVersion;
+
+function springCloudVersion([info, params]) {
+  return scsLib.getParamOrDefault(info, params, 'springCloudVersion', 'x-spring-cloud-version', SPRING_CLOUD_VERSION);
+}
+filter.springCloudVersion = springCloudVersion;
+
+function stringify(obj) {
+  var str = JSON.stringify(obj, null, 2);
+  return str;
+}
+filter.stringify = stringify;
+
+// This returns an object containing information the template needs to render topic strings.
+function topicInfo([channelName, channel]) {
+  let p = channel.parameters();
+  return getTopicInfo(channelName, channel);
+}
+filter.topicInfo = topicInfo;
+
+// Returns true if any property names will be different between json and java.
+function checkPropertyNames(name, schema) {
+  let ret = false;
+
+  //console.log(JSON.stringify(schema));
+  //console.log('checkPropertyNames: checking schema ' + name + getMethods(schema));
+  
+  var properties = schema.properties();
+  
+
+  if (schema.type() === 'array') {
+    properties = schema.items().properties();
+  }
+
+  //console.log("schema type: " + schema.type());
+
+  for (let propName in properties) {
+    let javaName = _.camelCase(propName);
+    let prop = properties[propName];
+    //console.log('checking ' + propName + ' ' + prop.type());
+
+    if (javaName !== propName) {
+      //console.log("Java name " + javaName + " is different from " + propName);
+      return true;
     }
-    return ret;
-  })
-
-  Nunjucks.addFilter('solaceSpringCloudVersion', ([info, params]) => {
-    var required = isApplication(params) && params.binder === 'solace';
-		return scsLib.getParamOrDefault(info, params, 'solaceSpringCloudVersion', 'x-solace-spring-cloud-version', SOLACE_SPRING_CLOUD_VERSION);
-  })
-
-  Nunjucks.addFilter('springBootVersion', ([info, params]) => {
-		return scsLib.getParamOrDefault(info, params, 'springBootVersion', 'x-spring-boot-version', SPRING_BOOT_VERSION);
-  })
-
-  Nunjucks.addFilter('springCloudStreamVersion', ([info, params]) => {
-		return scsLib.getParamOrDefault(info, params, 'springCloudStreamVersion', 'x-spring-cloud-stream-version', SPRING_CLOUD_STREAM_VERSION);
-  })
-
-  Nunjucks.addFilter('springCloudVersion', ([info, params]) => {
-		return scsLib.getParamOrDefault(info, params, 'springCloudVersion', 'x-spring-cloud-version', SPRING_CLOUD_VERSION);
-  })
-
-	Nunjucks.addFilter('stringify', (obj) => {
-    var str = JSON.stringify(obj, null, 2);
-    return str;
-  })
-
-
-  // This returns an object containing information the template needs to render topic strings.
-  Nunjucks.addFilter('topicInfo', ([channelName, channel]) => {
-    let p = channel.parameters();
-    return getTopicInfo(channelName, channel);
-  })
-
-  Nunjucks.addFilter('upperFirst', (str) => {
-    return _.upperFirst(str);
-  })
-
-  // Returns true if any property names will be different between json and java.
-  function checkPropertyNames(name, schema) {
-    let ret = false;
-
-    //console.log(JSON.stringify(schema));
-		//console.log('checkPropertyNames: checking schema ' + name + getMethods(schema));
-		
-    var properties = schema.properties();
-    
-
-		if (schema.type() === 'array') {
-      properties = schema.items().properties();
-		}
-
-    //console.log("schema type: " + schema.type());
-
-    for (let propName in properties) {
-      let javaName = _.camelCase(propName);
-      let prop = properties[propName];
-      //console.log('checking ' + propName + ' ' + prop.type());
-
-      if (javaName !== propName) {
-        //console.log("Java name " + javaName + " is different from " + propName);
+    if (prop.type === 'object') {
+      //console.log("Recursing into object");
+      let check = checkPropertyNames(propName, prop);
+      if (check) {
         return true;
       }
-      if (prop.type === 'object') {
-        //console.log("Recursing into object");
-        let check = checkPropertyNames(propName, prop);
+    } else if (prop.type === 'array') {
+      //console.log('checkPropertyNames: ' + JSON.stringify(prop));
+      if (!prop.items) {
+        throw new Error("Array named " + propName + " must have an 'items' property to indicate what type the array elements are.");
+      }
+      let itemsType = prop.items.type;
+      //console.log('checkPropertyNames: ' + JSON.stringify(prop.items));
+      //console.log('array of : ' + itemsType);
+      if (itemsType === 'object') {
+        //console.log("Recursing into array");
+        let check = checkPropertyNames(propName, prop.items);
         if (check) {
           return true;
         }
-      } else if (prop.type === 'array') {
-        //console.log('checkPropertyNames: ' + JSON.stringify(prop));
-        if (!prop.items) {
-          throw new Error("Array named " + propName + " must have an 'items' property to indicate what type the array elements are.");
-        }
-        let itemsType = prop.items.type;
-        //console.log('checkPropertyNames: ' + JSON.stringify(prop.items));
-        //console.log('array of : ' + itemsType);
-        if (itemsType === 'object') {
-          //console.log("Recursing into array");
-          let check = checkPropertyNames(propName, prop.items);
-          if (check) {
-            return true;
-          }
-        }
       }
     }
-    return ret;
   }
+  return ret;
+}
 
-  function dump(obj) {
-    let s = typeof obj;
-    for (let p in obj) {
-      s += " ";
-      s += p;
-    }
-    return s;
+function dump(obj) {
+  let s = typeof obj;
+  for (let p in obj) {
+    s += " ";
+    s += p;
   }
+  return s;
+}
 
-  // For the Solace binder. This determines the topic that must be subscribed to on a queue, when the x-scs-destination is given (which is the queue name.)
-  function getAdditionalSubs(asyncapi) {
-    let ret;
+// For the Solace binder. This determines the topic that must be subscribed to on a queue, when the x-scs-destination is given (which is the queue name.)
+function getAdditionalSubs(asyncapi) {
+  let ret;
 
-    for (let channelName in asyncapi.channels()) {
-      let channel = asyncapi.channels()[channelName];
-      let subscribe = channel.subscribe();
-      
-      if (subscribe) {
-        let functionName = getFunctionName(channelName, subscribe);
-        let topicInfo = getTopicInfo(channelName, channel);
-        let queue = subscribe.ext('x-scs-destination');
-        if (topicInfo.hasParams || queue) {
-          if (!ret) {
-            ret = {};
-            ret.bindings = {};
-          }
-          let bindingName = functionName + "-in-0";
-          ret.bindings[bindingName] = {};
-          ret.bindings[bindingName].consumer = {};
-          ret.bindings[bindingName].consumer.queueAdditionalSubscriptions = topicInfo.subscribeTopic;
-        }
-      }
-    } 
-
-    return ret;
-  }
-
-  // This returns the SCSt bindings config that will appear in application.yaml.
-  function getBindings(asyncapi, params) {
-    let ret = {};
-    let funcs = getFunctionSpecs(asyncapi, params);
-
-    funcs.forEach((spec, name, map) => {
-      if (spec.isPublisher) {
-        ret[spec.publishBindingName] = {};
-        ret[spec.publishBindingName].destination = spec.publishChannel;
-      }
-      if (spec.isSubscriber) {
-        ret[spec.subscribeBindingName] = {};
-				ret[spec.subscribeBindingName].destination = spec.subscribeChannel;
-				if (spec.group) {
-					ret[spec.subscribeBindingName].group = spec.group;
-				}
-      }
-    });
-    return ret;
-  }
-
-  // This returns the base function name that SCSt will use to map functions with bindings.
-  function getFunctionName(channelName, operation) {
-    let ret;
-    //console.log('functionName operation: ' + JSON.stringify(operation));
-    let functionName = operation.ext('x-scs-function-name');
-    //console.log(getMethods(operation));
-
-    if (!functionName) {
-      functionName = operation.id();
-    }
-
-    if (functionName) {
-      ret = functionName;
-    } else {
-      ret = _.camelCase(channelName) + (operation.isSubscribe() ? "Consumer" : "Supplier");
-    }
-    return ret;
-  }
-
-  
-  // This returns the base function name that SCSt will use to map functions with bindings.
-  function getFunctionNameByChannel(channelName, channel) {
-    let ret = _.camelCase(channelName);
-    //console.log('functionName channel: ' + JSON.stringify(channelJson));
-    let functionName = channel.ext('x-scs-function-name');
-    //console.log('function name for channel ' + channelName + ': ' + functionName);
-    if (functionName) {
-      ret = functionName;
-    }
-    return ret;
-  }
-
-  // This returns the string that gets rendered in the function.definition part of application.yaml.
-  function getFunctionDefinitions(asyncapi, params) {
-    let ret = "";
-    let funcs = getFunctionSpecs(asyncapi, params);
-    let names = funcs.keys();
-    ret = Array.from(names).join(";");
-    return ret;
-  }
-
-  function getFunctionSpecs(asyncapi, params) {
-    // This maps function names to SCS function definitions.
-    const functionMap = new Map();
-    const reactive = params.reactive === 'true';
-
-    for (let channelName in asyncapi.channels()) {
-      let channel = asyncapi.channels()[channelName];
-      //console.log("=====================================");
-      //console.log("channelJson: " + JSON.stringify(channel._json));
-      //console.log("getFunctionSpecs: " + channelName);
-      //console.log("=====================================");
-      let functionSpec;
-      let publish = channel.publish();
-      if (publish) {
-        let name = getFunctionName(channelName, publish);
-        functionSpec = functionMap.get(name);
-        if (functionSpec) {
-          if (functionSpec.type === 'supplier' || functionSpec === 'function') {
-            throw new Error(`Function ${name} can't publish to both channels {a.channel} and ${channelName}.`);
-          }
-          functionSpec.type = 'function';
-        } else {
-          functionSpec = new SCSFunction();
-          functionSpec.name = name;
-          functionSpec.type = 'supplier';
-          functionSpec.reactive = reactive;
-          functionMap.set(name, functionSpec);
-        }
-        let payload = getPayloadClass(channel.publish());
-        if (!payload) {
-          throw new Error("Channel " + channelName + ": no payload class has been defined.");
-        }
-        functionSpec.publishPayload = payload;
-        functionSpec.publishChannel = channelName;
-      }
-
-      let subscribe = channel.subscribe();
-      if (subscribe) {
-        let name = getFunctionName(channelName, subscribe);
-        functionSpec = functionMap.get(name);
-        if (functionSpec) {
-          if (functionSpec.type === 'consumer' || functionSpec === 'function') {
-            throw new Error(`Function ${name} can't subscribe to both channels {functionSpec.channel} and ${channelName}.`);
-          }
-          functionSpec.type = 'function'
-        } else {
-          functionSpec = new SCSFunction();
-          functionSpec.name = name;
-          functionSpec.type = 'consumer';
-          functionSpec.reactive = reactive;
-          functionMap.set(name, functionSpec);
-        }
-        let payload = getPayloadClass(subscribe);
-        if (!payload) {
-          throw new Error("Channel " + channelName + ": no payload class has been defined.");
-        }
-        functionSpec.subscribePayload = payload;
-        var group = subscribe.ext('x-scs-group');
-        if (group) {
-            functionSpec.group = group;
-        }
-        var dest = subscribe.ext('x-scs-destination');
-        if (dest) {
-            functionSpec.subscribeChannel = dest;
-        } else {
-            functionSpec.subscribeChannel = channelName;
-        }
-      }
-    }
-
-    return functionMap;
-  }
-  
-  const getMethods = (obj) => {
-    let properties = new Set()
-    let currentObj = obj
-    do {
-      Object.getOwnPropertyNames(currentObj).map(item => properties.add(item))
-    } while ((currentObj = Object.getPrototypeOf(currentObj)))
-    return [...properties.keys()].filter(item => typeof obj[item] === 'function')
-  }
-
-  function getPayloadClass(pubOrSub) {
-    let ret;
-
-    if (pubOrSub) {
-      //console.log(pubOrSub);
-
-      if (pubOrSub.hasMultipleMessages()) {
-        ret = 'Message<?>';
-      } else {
-
-      let message = pubOrSub.message();
-      if (message) {
-        let payload = message.payload();
-
-        if (payload) {
-          ret = payload.ext('x-parser-schema-id');
-        }
-      }
-    }
-    //console.log("getPayloadClass: " + ret);
-    }
+  for (let channelName in asyncapi.channels()) {
+    let channel = asyncapi.channels()[channelName];
+    let subscribe = channel.subscribe();
     
-    return ret;
-  }
-
-  // This returns the connection properties for a solace binder, for application.yaml.
-  function getSolace(params) {
-    let ret = {};
-    ret.java = {};
-    ret.java.host = params.host || SOLACE_HOST;
-    ret.java.msgVpn = params.msgVpn || SOLACE_DEFAULT;
-    ret.java.clientUsername = params.username || SOLACE_DEFAULT;
-    ret.java.clientPassword = params.password || SOLACE_DEFAULT;
-    return ret;
-  }
-
-  // This returns an object containing information the template needs to render topic strings.
-  function getTopicInfo(channelName, channel) {
-    const ret = {};
-    let publishTopic = String(channelName);
-    let subscribeTopic = String(channelName);
-    const params = [];
-    let functionParamList = "";
-    let functionArgList = "";
-    let sampleArgList = "";
-    let first = true;
-
-    //console.log("params: " + JSON.stringify(channel.parameters()));
-    for (let name in channel.parameters()) {
-      const nameWithBrackets = "{" + name + "}";
-      const parameter = channel.parameter(name);
-      const schema = parameter.schema();
-      const type = schema.type();
-      const param = { "name": _.lowerFirst(name) };
-      //console.log("name: " + name + " type: " + type);
-      let sampleArg = 1;
-
-      if (first) {
-        first = false;
-      } else {
-        functionParamList += ", ";
-        functionArgList += ", ";
-      }
-
-      sampleArgList += ", ";
-
-      if (type) {
-        //console.log("It's a type: " + type);
-        const javaType = typeMap.get(type);
-        if (!javaType) throw new Error("topicInfo filter: type not found in typeMap: " + type);
-        param.type = javaType;
-        const printfArg = formatMap.get(type);
-        //console.log("printf: " + printfArg);
-        if (!printfArg) throw new Error("topicInfo filter: type not found in formatMap: " + type);
-        //console.log("Replacing " + nameWithBrackets);
-        publishTopic = publishTopic.replace(nameWithBrackets, printfArg);
-        sampleArg = sampleMap.get(type);
-      } else {
-        const en = schema.enum();
-        if (en) {
-          //console.log("It's an enum: " + en);
-          param.type = _.upperFirst(name);
-          param.enum = en;
-          sampleArg = "Messaging." + param.type + "." + en[0];
-          //console.log("Replacing " + nameWithBrackets);
-          publishTopic = publishTopic.replace(nameWithBrackets, "%s");
-        } else {
-          throw new Error("topicInfo filter: Unknown parameter type: " + JSON.stringify(schema));
+    if (subscribe) {
+      let functionName = getFunctionName(channelName, subscribe);
+      let topicInfo = getTopicInfo(channelName, channel);
+      let queue = subscribe.ext('x-scs-destination');
+      if (topicInfo.hasParams || queue) {
+        if (!ret) {
+          ret = {};
+          ret.bindings = {};
         }
+        let bindingName = functionName + "-in-0";
+        ret.bindings[bindingName] = {};
+        ret.bindings[bindingName].consumer = {};
+        ret.bindings[bindingName].consumer.queueAdditionalSubscriptions = topicInfo.subscribeTopic;
       }
-
-      subscribeTopic = subscribeTopic.replace(nameWithBrackets, "*");
-      functionParamList += param.type + " " + param.name;
-      functionArgList += param.name;
-      sampleArgList += sampleArg;
-      params.push(param);
     }
-    ret.functionArgList = functionArgList;
-    ret.functionParamList = functionParamList;
-    ret.sampleArgList = sampleArgList;
-    ret.channelName = channelName;
-    ret.params = params;
-    ret.publishTopic = publishTopic;
-    ret.subscribeTopic = subscribeTopic;
-    ret.hasParams = params.length > 0;
-    return ret;
+  } 
+
+  return ret;
+}
+
+// This returns the SCSt bindings config that will appear in application.yaml.
+function getBindings(asyncapi, params) {
+  let ret = {};
+  let funcs = getFunctionSpecs(asyncapi, params);
+
+  funcs.forEach((spec, name, map) => {
+    if (spec.isPublisher) {
+      ret[spec.publishBindingName] = {};
+      ret[spec.publishBindingName].destination = spec.publishChannel;
+    }
+    if (spec.isSubscriber) {
+      ret[spec.subscribeBindingName] = {};
+      ret[spec.subscribeBindingName].destination = spec.subscribeChannel;
+      if (spec.group) {
+        ret[spec.subscribeBindingName].group = spec.group;
+      }
+    }
+  });
+  return ret;
+}
+
+// This returns the base function name that SCSt will use to map functions with bindings.
+function getFunctionName(channelName, operation) {
+  let ret;
+  //console.log('functionName operation: ' + JSON.stringify(operation));
+  let functionName = operation.ext('x-scs-function-name');
+  //console.log(getMethods(operation));
+
+  if (!functionName) {
+    functionName = operation.id();
   }
 
-  function indent(numTabs) {
-    return "\t".repeat(numTabs);
+  if (functionName) {
+    ret = functionName;
+  } else {
+    ret = _.camelCase(channelName) + (operation.isSubscribe() ? "Consumer" : "Supplier");
+  }
+  return ret;
+}
+
+
+// This returns the base function name that SCSt will use to map functions with bindings.
+function getFunctionNameByChannel(channelName, channel) {
+  let ret = _.camelCase(channelName);
+  //console.log('functionName channel: ' + JSON.stringify(channelJson));
+  let functionName = channel.ext('x-scs-function-name');
+  //console.log('function name for channel ' + channelName + ': ' + functionName);
+  if (functionName) {
+    ret = functionName;
+  }
+  return ret;
+}
+
+// This returns the string that gets rendered in the function.definition part of application.yaml.
+function getFunctionDefinitions(asyncapi, params) {
+  let ret = "";
+  let funcs = getFunctionSpecs(asyncapi, params);
+  let names = funcs.keys();
+  ret = Array.from(names).join(";");
+  return ret;
+}
+
+function getFunctionSpecs(asyncapi, params) {
+  // This maps function names to SCS function definitions.
+  const functionMap = new Map();
+  const reactive = params.reactive === 'true';
+
+  for (let channelName in asyncapi.channels()) {
+    let channel = asyncapi.channels()[channelName];
+    //console.log("=====================================");
+    //console.log("channelJson: " + JSON.stringify(channel._json));
+    //console.log("getFunctionSpecs: " + channelName);
+    //console.log("=====================================");
+    let functionSpec;
+    let publish = channel.publish();
+    if (publish) {
+      let name = getFunctionName(channelName, publish);
+      functionSpec = functionMap.get(name);
+      if (functionSpec) {
+        if (functionSpec.type === 'supplier' || functionSpec === 'function') {
+          throw new Error(`Function ${name} can't publish to both channels {a.channel} and ${channelName}.`);
+        }
+        functionSpec.type = 'function';
+      } else {
+        functionSpec = new SCSFunction();
+        functionSpec.name = name;
+        functionSpec.type = 'supplier';
+        functionSpec.reactive = reactive;
+        functionMap.set(name, functionSpec);
+      }
+      let payload = getPayloadClass(channel.publish());
+      if (!payload) {
+        throw new Error("Channel " + channelName + ": no payload class has been defined.");
+      }
+      functionSpec.publishPayload = payload;
+      functionSpec.publishChannel = channelName;
+    }
+
+    let subscribe = channel.subscribe();
+    if (subscribe) {
+      let name = getFunctionName(channelName, subscribe);
+      functionSpec = functionMap.get(name);
+      if (functionSpec) {
+        if (functionSpec.type === 'consumer' || functionSpec === 'function') {
+          throw new Error(`Function ${name} can't subscribe to both channels {functionSpec.channel} and ${channelName}.`);
+        }
+        functionSpec.type = 'function'
+      } else {
+        functionSpec = new SCSFunction();
+        functionSpec.name = name;
+        functionSpec.type = 'consumer';
+        functionSpec.reactive = reactive;
+        functionMap.set(name, functionSpec);
+      }
+      let payload = getPayloadClass(subscribe);
+      if (!payload) {
+        throw new Error("Channel " + channelName + ": no payload class has been defined.");
+      }
+      functionSpec.subscribePayload = payload;
+      var group = subscribe.ext('x-scs-group');
+      if (group) {
+          functionSpec.group = group;
+      }
+      var dest = subscribe.ext('x-scs-destination');
+      if (dest) {
+          functionSpec.subscribeChannel = dest;
+      } else {
+          functionSpec.subscribeChannel = channelName;
+      }
+    }
   }
 
-  function isApplication(params) {
-    var artifactType = params.artifactType;
-    return (!artifactType || artifactType === 'application')
+  return functionMap;
+}
+
+const getMethods = (obj) => {
+  let properties = new Set()
+  let currentObj = obj
+  do {
+    Object.getOwnPropertyNames(currentObj).map(item => properties.add(item))
+  } while ((currentObj = Object.getPrototypeOf(currentObj)))
+  return [...properties.keys()].filter(item => typeof obj[item] === 'function')
+}
+
+function getPayloadClass(pubOrSub) {
+  let ret;
+
+  if (pubOrSub) {
+    //console.log(pubOrSub);
+
+    if (pubOrSub.hasMultipleMessages()) {
+      ret = 'Message<?>';
+    } else {
+
+    let message = pubOrSub.message();
+    if (message) {
+      let payload = message.payload();
+
+      if (payload) {
+        ret = payload.ext('x-parser-schema-id');
+      }
+    }
   }
+  //console.log("getPayloadClass: " + ret);
+  }
+  
+  return ret;
+}
+
+// This returns the connection properties for a solace binder, for application.yaml.
+function getSolace(params) {
+  let ret = {};
+  ret.java = {};
+  ret.java.host = params.host || SOLACE_HOST;
+  ret.java.msgVpn = params.msgVpn || SOLACE_DEFAULT;
+  ret.java.clientUsername = params.username || SOLACE_DEFAULT;
+  ret.java.clientPassword = params.password || SOLACE_DEFAULT;
+  return ret;
+}
+
+// This returns an object containing information the template needs to render topic strings.
+function getTopicInfo(channelName, channel) {
+  const ret = {};
+  let publishTopic = String(channelName);
+  let subscribeTopic = String(channelName);
+  const params = [];
+  let functionParamList = "";
+  let functionArgList = "";
+  let sampleArgList = "";
+  let first = true;
+
+  //console.log("params: " + JSON.stringify(channel.parameters()));
+  for (let name in channel.parameters()) {
+    const nameWithBrackets = "{" + name + "}";
+    const parameter = channel.parameter(name);
+    const schema = parameter.schema();
+    const type = schema.type();
+    const param = { "name": _.lowerFirst(name) };
+    //console.log("name: " + name + " type: " + type);
+    let sampleArg = 1;
+
+    if (first) {
+      first = false;
+    } else {
+      functionParamList += ", ";
+      functionArgList += ", ";
+    }
+
+    sampleArgList += ", ";
+
+    if (type) {
+      //console.log("It's a type: " + type);
+      const javaType = typeMap.get(type);
+      if (!javaType) throw new Error("topicInfo filter: type not found in typeMap: " + type);
+      param.type = javaType;
+      const printfArg = formatMap.get(type);
+      //console.log("printf: " + printfArg);
+      if (!printfArg) throw new Error("topicInfo filter: type not found in formatMap: " + type);
+      //console.log("Replacing " + nameWithBrackets);
+      publishTopic = publishTopic.replace(nameWithBrackets, printfArg);
+      sampleArg = sampleMap.get(type);
+    } else {
+      const en = schema.enum();
+      if (en) {
+        //console.log("It's an enum: " + en);
+        param.type = _.upperFirst(name);
+        param.enum = en;
+        sampleArg = "Messaging." + param.type + "." + en[0];
+        //console.log("Replacing " + nameWithBrackets);
+        publishTopic = publishTopic.replace(nameWithBrackets, "%s");
+      } else {
+        throw new Error("topicInfo filter: Unknown parameter type: " + JSON.stringify(schema));
+      }
+    }
+
+    subscribeTopic = subscribeTopic.replace(nameWithBrackets, "*");
+    functionParamList += param.type + " " + param.name;
+    functionArgList += param.name;
+    sampleArgList += sampleArg;
+    params.push(param);
+  }
+  ret.functionArgList = functionArgList;
+  ret.functionParamList = functionParamList;
+  ret.sampleArgList = sampleArgList;
+  ret.channelName = channelName;
+  ret.params = params;
+  ret.publishTopic = publishTopic;
+  ret.subscribeTopic = subscribeTopic;
+  ret.hasParams = params.length > 0;
+  return ret;
+}
+
+function indent(numTabs) {
+  return "\t".repeat(numTabs);
+}
+
+function isApplication(params) {
+  var artifactType = params.artifactType;
+  return (!artifactType || artifactType === 'application')
 }

--- a/hooks/post-process.js
+++ b/hooks/post-process.js
@@ -1,21 +1,20 @@
 // vim: set ts=2 sw=2 sts=2 expandtab :
 const fs = require('fs');
 const path = require('path');
-const _ = require('lodash');
 const ScsLib = require('../lib/ScsLib');
 
 const sourceHead = '/src/main/java/';
 
 module.exports = register => {
   register('generate:after', generator => {
-	var scsLib = new ScsLib();
+    const scsLib = new ScsLib();
     const asyncapi = generator.asyncapi;
     let sourcePath = generator.targetDir + sourceHead;
     const info = asyncapi.info();
     let package = generator.templateParams['javaPackage'];
     let generateMessagingClass = false;
-    let gen = generator.templateParams['generateMessagingClass'];
-    let extensions = info.extensions();
+    const gen = generator.templateParams['generateMessagingClass'];
+    const extensions = info.extensions();
 
     if (gen === 'true') {
       generateMessagingClass = true;
@@ -27,7 +26,7 @@ module.exports = register => {
 
     if (package) {
       //console.log("package: " + package);
-      const overridePath = generator.targetDir + sourceHead + package.replace(/\./g, '/') + '/';
+      const overridePath = `${generator.targetDir + sourceHead + package.replace(/\./g, '/')  }/`;
       //console.log("Moving files from " + sourcePath + " to " + overridePath);
       let first = true;
       fs.readdirSync(sourcePath).forEach(file => {
@@ -42,32 +41,30 @@ module.exports = register => {
           //console.log("Copying " + file)
         }
         fs.unlinkSync(path.resolve(sourcePath, file));
-      })
+      });
       sourcePath = overridePath;
-    } else {
-      if (!generateMessagingClass) {
-        fs.unlinkSync(path.resolve(sourcePath, 'Messaging.java'));
-      }
+    } else if (!generateMessagingClass) {
+      fs.unlinkSync(path.resolve(sourcePath, 'Messaging.java'));
     }
 
     // Rename the pom file if necessary, and only include Application.java when an app is requested.
-    let artifactType = generator.templateParams['artifactType'];
+    const artifactType = generator.templateParams['artifactType'];
 
-    let mainClassName = "Application";
+    const mainClassName = 'Application';
 	  let overrideClassName = scsLib.getParamOrExtension(info, generator.templateParams, 'javaClass', 'x-java-class');
 
-    if (artifactType === "library") {
-      fs.renameSync(path.resolve(generator.targetDir, "pom.lib"), path.resolve(generator.targetDir, "pom.xml"));
-      fs.unlinkSync(path.resolve(generator.targetDir, "pom.app"));
-      fs.unlinkSync(path.resolve(sourcePath, "Application.java"));
+    if (artifactType === 'library') {
+      fs.renameSync(path.resolve(generator.targetDir, 'pom.lib'), path.resolve(generator.targetDir, 'pom.xml'));
+      fs.unlinkSync(path.resolve(generator.targetDir, 'pom.app'));
+      fs.unlinkSync(path.resolve(sourcePath, 'Application.java'));
       //fs.unlinkSync(path.resolve(sourcePath, "ApplicationWithMessaging.java"));
     } else {
-      fs.renameSync(path.resolve(generator.targetDir, "pom.app"), path.resolve(generator.targetDir, "pom.xml"));
-      fs.unlinkSync(path.resolve(generator.targetDir, "pom.lib"));
+      fs.renameSync(path.resolve(generator.targetDir, 'pom.app'), path.resolve(generator.targetDir, 'pom.xml'));
+      fs.unlinkSync(path.resolve(generator.targetDir, 'pom.lib'));
 
       if (overrideClassName) {
 		    overrideClassName += '.java';
-        fs.renameSync(path.resolve(sourcePath, "Application.java"), path.resolve(sourcePath, overrideClassName));
+        fs.renameSync(path.resolve(sourcePath, 'Application.java'), path.resolve(sourcePath, overrideClassName));
       }
     }
 
@@ -91,11 +88,5 @@ module.exports = register => {
       }
     }
     */
-  })
-}
-
-function dump(obj) {
-  for (p in obj) {
-    console.log(p);
-  }
-}
+  });
+};

--- a/hooks/post-process.js
+++ b/hooks/post-process.js
@@ -90,3 +90,4 @@ module.exports = register => {
     */
   });
 };
+

--- a/lib/scsLib.js
+++ b/lib/scsLib.js
@@ -1,26 +1,25 @@
 // This contains functions taht are common to both the all.js filter and the post-process.js hook.
-var _ = require('lodash');
+const _ = require('lodash');
 
 class ScsLib {
+  // This returns a valid Java class name.
+  getClassName(name) {
+    const ret = this.getIdentifierName(name);
+    return _.upperFirst(ret);
+  }
 
-	// This returns a valid Java class name.
-	getClassName(name) {
-		let ret = this.getIdentifierName(name);
-		return _.upperFirst(ret);
-	}
+  // This returns a valid Java identifier name.
+  getIdentifierName(name) {
+    let ret = _.camelCase(name);
 
-	// This returns a valid Java identifier name.
-	getIdentifierName(name) {
-		let ret = _.camelCase(name);
+    if (ScsLib.reservedWords.has(ret)) {
+      ret = `_${  ret}`;
+    }
 
-		if (ScsLib.reservedWords.has(ret)) {
-			ret = '_' + ret;
-		}
+    return ret;
+  }
 
-		return ret;
-	}
-
-// This returns the value of a param, or specification extention if the param isn't set. 
+  // This returns the value of a param, or specification extention if the param isn't set. 
   // If neither is set and the required flag is true, it throws an error.
   getParamOrExtension(info, params, paramName, extensionName, description, example, required) {
     let ret = '';
@@ -36,19 +35,17 @@ class ScsLib {
 
   // This returns the value of a param, or specification extention if the param isn't set. 
   // If neither is set it returns defaultValue.
-	getParamOrDefault(info, params, paramName, extensionName, defaultValue) {
-		let ret = '';
-		if (params[paramName]) {
-			ret = params[paramName];
-		} else if (info.extensions()[extensionName]) {
-			ret = info.extensions()[extensionName];
-		} else  {
-			ret = defaultValue;
-		}
-		return ret;
-	}
-
-
+  getParamOrDefault(info, params, paramName, extensionName, defaultValue) {
+    let ret = '';
+    if (params[paramName]) {
+      ret = params[paramName];
+    } else if (info.extensions()[extensionName]) {
+      ret = info.extensions()[extensionName];
+    } else  {
+      ret = defaultValue;
+    }
+    return ret;
+  }
 }
 
 // This is the set of Java reserved words, to ensure that we don't generate reserved words.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,8 +5,9 @@
   "requires": true,
   "dependencies": {
     "@asyncapi/generator-filters": {
-      "version": "git+https://github.com/derberg/generator-filters.git#27c279ddc53809211269ee143b6ca686f0212b75",
-      "from": "git+https://github.com/derberg/generator-filters.git#use-filters-lib",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/generator-filters/-/generator-filters-1.0.0.tgz",
+      "integrity": "sha512-LcqLwUh/PqcHzIyEWxPT3pIehzif8d7aVq/CBWx0Hni7x/jsEbQhvtgT8LQpwHFLTZrNAKuxGivzOk3Ero+SQQ==",
       "requires": {
         "lodash": "^4.17.15",
         "markdown-it": "^10.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1139,9 +1139,9 @@
       },
       "dependencies": {
         "cross-spawn": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
-          "integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
+          "version": "7.0.2",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.2.tgz",
+          "integrity": "sha512-PD6G8QG3S4FK/XCGFbEQrDqO2AnMMsy0meR7lerlIOHAAbkuavGU/pOqprrlvfTNjvowivTeBsjebAL0NSoMxw==",
           "dev": true,
           "requires": {
             "path-key": "^3.1.0",
@@ -2196,23 +2196,23 @@
       }
     },
     "marked": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.2.tgz",
-      "integrity": "sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-1.0.0.tgz",
+      "integrity": "sha512-Wo+L1pWTVibfrSr+TTtMuiMfNzmZWiOPeO7rZsQUY5bgsxpHesBEcIWJloWVTFnrMXnf/TL30eTFSGJddmQAng==",
       "dev": true
     },
     "marked-terminal": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-4.0.0.tgz",
-      "integrity": "sha512-mzU3VD7aVz12FfGoKFAceijehA6Ocjfg3rVimvJbFAB/NOYCsuzRVtq3PSFdPmWI5mhdGeEh3/aMJ5DSxAz94Q==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-4.1.0.tgz",
+      "integrity": "sha512-5KllfAOW02WS6hLRQ7cNvGOxvKW1BKuXELH4EtbWfyWgxQhROoMxEvuQ/3fTgkNjledR0J48F4HbapvYp1zWkQ==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^4.3.0",
+        "ansi-escapes": "^4.3.1",
         "cardinal": "^2.1.1",
-        "chalk": "^3.0.0",
+        "chalk": "^4.0.0",
         "cli-table": "^0.3.1",
         "node-emoji": "^1.10.0",
-        "supports-hyperlinks": "^2.0.0"
+        "supports-hyperlinks": "^2.1.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -2226,9 +2226,9 @@
           }
         },
         "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.0.0.tgz",
+          "integrity": "sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -6429,9 +6429,9 @@
       "dev": true
     },
     "semantic-release": {
-      "version": "17.0.4",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-17.0.4.tgz",
-      "integrity": "sha512-5y9QRSrZtdvACmlpX5DvEVsvFuKRDUVn7JVJFxPVLGrGofDf1d0M/+hA1wFmCjiJZ+VCY8bYaSqVqF14KCF9rw==",
+      "version": "17.0.7",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-17.0.7.tgz",
+      "integrity": "sha512-F6FzJI1yiGavzCTXir4yPthK/iozZPJ4myUYndiHhSHbmOcCSJ2m7V+P6sFwVpDpQKQp1Q31M68sTJ/Q/27Bow==",
       "dev": true,
       "requires": {
         "@semantic-release/commit-analyzer": "^8.0.0",
@@ -6451,23 +6451,23 @@
         "hook-std": "^2.0.0",
         "hosted-git-info": "^3.0.0",
         "lodash": "^4.17.15",
-        "marked": "^0.8.0",
+        "marked": "^1.0.0",
         "marked-terminal": "^4.0.0",
         "micromatch": "^4.0.2",
         "p-each-series": "^2.1.0",
         "p-reduce": "^2.0.0",
         "read-pkg-up": "^7.0.0",
         "resolve-from": "^5.0.0",
-        "semver": "^7.1.1",
+        "semver": "^7.3.2",
         "semver-diff": "^3.1.1",
         "signale": "^1.2.1",
         "yargs": "^15.0.1"
       },
       "dependencies": {
         "cross-spawn": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
-          "integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
+          "version": "7.0.2",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.2.tgz",
+          "integrity": "sha512-PD6G8QG3S4FK/XCGFbEQrDqO2AnMMsy0meR7lerlIOHAAbkuavGU/pOqprrlvfTNjvowivTeBsjebAL0NSoMxw==",
           "dev": true,
           "requires": {
             "path-key": "^3.1.0",
@@ -6545,9 +6545,9 @@
           }
         },
         "p-limit": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-          "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
           "dev": true,
           "requires": {
             "p-try": "^2.0.0"
@@ -6624,9 +6624,9 @@
           }
         },
         "semver": {
-          "version": "7.1.3",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.1.3.tgz",
-          "integrity": "sha512-ekM0zfiA9SCBlsKa2X1hxyxiI4L3B6EbVJkkdgQXnSEEaHlGdvyodMruTiulSRWMMB4NeIuYNMC9rTKTz97GxA==",
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
           "dev": true
         },
         "shebang-command": {
@@ -7301,12 +7301,12 @@
       "dev": true
     },
     "yaml": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.8.3.tgz",
-      "integrity": "sha512-X/v7VDnK+sxbQ2Imq4Jt2PRUsRsP7UcpSl3Llg6+NRRqWLIvxkMFYtH1FmvwNGYRKKPa+EPA4qDBlI9WVG1UKw==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.9.2.tgz",
+      "integrity": "sha512-HPT7cGGI0DuRcsO51qC1j9O16Dh1mZ2bnXwsi0jrSpsLz0WxOLSLXfkABVl6bZO629py3CU+OMJtpNHDLB97kg==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.8.7"
+        "@babel/runtime": "^7.9.2"
       }
     },
     "yargs": {
@@ -7354,9 +7354,9 @@
           }
         },
         "p-limit": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-          "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
           "dev": true,
           "requires": {
             "p-try": "^2.0.0"
@@ -7384,9 +7384,9 @@
           "dev": true
         },
         "yargs-parser": {
-          "version": "18.1.2",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.2.tgz",
-          "integrity": "sha512-hlIPNR3IzC1YuL1c2UwwDKpXlNFBqD1Fswwh1khz5+d8Cq/8yc/Mn0i+rQXduu8hcrFKvO7Eryk+09NecTQAAQ==",
+          "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
           "dev": true,
           "requires": {
             "camelcase": "^5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,15 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@asyncapi/generator-filters": {
+      "version": "git+https://github.com/derberg/generator-filters.git#27c279ddc53809211269ee143b6ca686f0212b75",
+      "from": "git+https://github.com/derberg/generator-filters.git#use-filters-lib",
+      "requires": {
+        "lodash": "^4.17.15",
+        "markdown-it": "^10.0.0",
+        "openapi-sampler": "^1.0.0-beta.15"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
@@ -547,6 +556,18 @@
         "through": ">=2.2.7 <3"
       }
     },
+    "acorn": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+      "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
+      "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
+      "dev": true
+    },
     "agent-base": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.0.tgz",
@@ -572,6 +593,18 @@
           "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
           "dev": true
         }
+      }
+    },
+    "ajv": {
+      "version": "6.12.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
+      "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
       }
     },
     "ansi-escapes": {
@@ -650,10 +683,22 @@
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
+    "astral-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+      "dev": true
+    },
     "at-least-node": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
     "before-after-hook": {
@@ -667,6 +712,16 @@
       "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
       "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
       "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
     },
     "braces": {
       "version": "3.0.2",
@@ -721,11 +776,26 @@
         "supports-color": "^5.3.0"
       }
     },
+    "chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
     "clean-stack": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
       "dev": true
+    },
+    "cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "^3.1.0"
+      }
     },
     "cli-table": {
       "version": "0.3.1",
@@ -735,6 +805,12 @@
       "requires": {
         "colors": "1.0.3"
       }
+    },
+    "cli-width": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
+      "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
+      "dev": true
     },
     "cliui": {
       "version": "6.0.0",
@@ -784,6 +860,12 @@
         "array-ify": "^1.0.0",
         "dot-prop": "^3.0.0"
       }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "conventional-changelog-angular": {
       "version": "5.0.6",
@@ -969,6 +1051,12 @@
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "dev": true
     },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
     "deprecation": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
@@ -990,6 +1078,15 @@
           "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
           "dev": true
         }
+      }
+    },
+    "doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
       }
     },
     "dot-prop": {
@@ -1024,6 +1121,11 @@
       "requires": {
         "once": "^1.4.0"
       }
+    },
+    "entities": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
+      "integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw=="
     },
     "env-ci": {
       "version": "5.0.2",
@@ -1134,10 +1236,164 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
+    "eslint": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
+      "integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "ajv": "^6.10.0",
+        "chalk": "^2.1.0",
+        "cross-spawn": "^6.0.5",
+        "debug": "^4.0.1",
+        "doctrine": "^3.0.0",
+        "eslint-scope": "^5.0.0",
+        "eslint-utils": "^1.4.3",
+        "eslint-visitor-keys": "^1.1.0",
+        "espree": "^6.1.2",
+        "esquery": "^1.0.1",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^5.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob-parent": "^5.0.0",
+        "globals": "^12.1.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^7.0.0",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^3.13.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.14",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.3",
+        "progress": "^2.0.0",
+        "regexpp": "^2.0.1",
+        "semver": "^6.1.2",
+        "strip-ansi": "^5.2.0",
+        "strip-json-comments": "^3.0.1",
+        "table": "^5.2.3",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "ignore": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+          "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+          "dev": true
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "strip-json-comments": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.0.tgz",
+          "integrity": "sha512-e6/d0eBu7gHtdCqFt0xJr642LdToM5/cN4Qb9DbHjVx1CP5RyeM+zH7pbecEmDv/lBqb0QH+6Uqq75rxFPkM0w==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-scope": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
+      "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "eslint-utils": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+      "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.1.0"
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+      "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+      "dev": true
+    },
+    "espree": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
+      "integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
+      "dev": true,
+      "requires": {
+        "acorn": "^7.1.1",
+        "acorn-jsx": "^5.2.0",
+        "eslint-visitor-keys": "^1.1.0"
+      }
+    },
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+    },
+    "esquery": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz",
+      "integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.1.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.1.0.tgz",
+          "integrity": "sha512-FyohXK+R0vE+y1nHLoBM7ZTyqRpqAlhdZHCWIWEviFLiGB8b04H6bQs8G+XTthacvT8VuwvteiP7RJSxMs8UEw==",
+          "dev": true
+        }
+      }
+    },
+    "esrecurse": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.1.0"
+      }
+    },
+    "estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true
     },
     "execa": {
       "version": "1.0.0",
@@ -1154,6 +1410,23 @@
         "strip-eof": "^1.0.0"
       }
     },
+    "external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "dev": true,
+      "requires": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      }
+    },
+    "fast-deep-equal": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+      "dev": true
+    },
     "fast-glob": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.2.tgz",
@@ -1167,6 +1440,18 @@
         "micromatch": "^4.0.2",
         "picomatch": "^2.2.1"
       }
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
     },
     "fastq": {
       "version": "1.6.1",
@@ -1184,6 +1469,15 @@
       "dev": true,
       "requires": {
         "escape-string-regexp": "^1.0.5"
+      }
+    },
+    "file-entry-cache": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+      "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^2.0.1"
       }
     },
     "fill-range": {
@@ -1213,6 +1507,28 @@
         "semver-regex": "^2.0.0"
       }
     },
+    "flat-cache": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+      "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+      "dev": true,
+      "requires": {
+        "flatted": "^2.0.0",
+        "rimraf": "2.6.3",
+        "write": "1.0.3"
+      }
+    },
+    "flatted": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
+      "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
+      "dev": true
+    },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+    },
     "from2": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
@@ -1234,6 +1550,18 @@
         "jsonfile": "^6.0.1",
         "universalify": "^1.0.0"
       }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
     },
     "get-caller-file": {
       "version": "2.0.5",
@@ -1285,6 +1613,20 @@
         }
       }
     },
+    "glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
     "glob-parent": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
@@ -1292,6 +1634,23 @@
       "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
+      }
+    },
+    "globals": {
+      "version": "12.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+      "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.8.1"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+          "dev": true
+        }
       }
     },
     "globby": {
@@ -1371,6 +1730,15 @@
       "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
       "dev": true
     },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
     "ignore": {
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
@@ -1404,11 +1772,27 @@
         "resolve-from": "^5.0.0"
       }
     },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
     "indent-string": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
       "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
       "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
     },
     "inherits": {
       "version": "2.0.4",
@@ -1421,6 +1805,79 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true
+    },
+    "inquirer": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.1.0.tgz",
+      "integrity": "sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^3.0.0",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.15",
+        "mute-stream": "0.0.8",
+        "run-async": "^2.4.0",
+        "rxjs": "^6.5.3",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "through": "^2.3.6"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
     },
     "into-stream": {
       "version": "5.1.1",
@@ -1559,6 +2016,26 @@
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
     },
+    "json-pointer": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/json-pointer/-/json-pointer-0.6.0.tgz",
+      "integrity": "sha1-jlAFUKaqxUZKRzN32leqbMIoKNc=",
+      "requires": {
+        "foreach": "^2.0.4"
+      }
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -1581,11 +2058,29 @@
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
     },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      }
+    },
     "lines-and-columns": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
       "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
       "dev": true
+    },
+    "linkify-it": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
+      "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
+      "requires": {
+        "uc.micro": "^1.0.1"
+      }
     },
     "load-json-file": {
       "version": "4.0.0",
@@ -1687,6 +2182,18 @@
       "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
       "dev": true
     },
+    "markdown-it": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-10.0.0.tgz",
+      "integrity": "sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==",
+      "requires": {
+        "argparse": "^1.0.7",
+        "entities": "~2.0.0",
+        "linkify-it": "^2.0.0",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
+      }
+    },
     "marked": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.2.tgz",
@@ -1759,6 +2266,11 @@
         }
       }
     },
+    "mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
+    },
     "meow": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-5.0.0.tgz",
@@ -1810,6 +2322,15 @@
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true
     },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
@@ -1826,6 +2347,15 @@
         "is-plain-obj": "^1.1.0"
       }
     },
+    "mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5"
+      }
+    },
     "modify-values": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
@@ -1836,6 +2366,18 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
     "neo-async": {
@@ -5457,6 +5999,14 @@
         "mimic-fn": "^2.1.0"
       }
     },
+    "openapi-sampler": {
+      "version": "1.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.0.0-beta.15.tgz",
+      "integrity": "sha512-wUD/vD3iBHKik/sME3uwUu4X3HFA53rDrPcVvLzgEELjHLbnTpSYfm4Jo9qZT1dPfBRowAnrF/VRQfOjL5QRAw==",
+      "requires": {
+        "json-pointer": "^0.6.0"
+      }
+    },
     "optimist": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
@@ -5475,6 +6025,20 @@
         }
       }
     },
+    "optionator": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+      "dev": true,
+      "requires": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.6",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "word-wrap": "~1.2.3"
+      }
+    },
     "os-name": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/os-name/-/os-name-3.1.0.tgz",
@@ -5484,6 +6048,12 @@
         "macos-release": "^2.2.0",
         "windows-release": "^3.1.0"
       }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
     },
     "p-each-series": {
       "version": "2.1.0",
@@ -5583,6 +6153,12 @@
       "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
       "dev": true
     },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
     "path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
@@ -5626,10 +6202,22 @@
         "load-json-file": "^4.0.0"
       }
     },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
+    },
+    "progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
     "pump": {
@@ -5641,6 +6229,12 @@
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
       }
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
     },
     "q": {
       "version": "1.5.1",
@@ -5727,6 +6321,12 @@
       "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
       "dev": true
     },
+    "regexpp": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+      "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+      "dev": true
+    },
     "registry-auth-token": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.1.1.tgz",
@@ -5763,6 +6363,16 @@
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
       "dev": true
     },
+    "restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "requires": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
     "retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
@@ -5775,16 +6385,46 @@
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
       "dev": true
     },
+    "rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "run-async": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+      "dev": true
+    },
     "run-parallel": {
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
       "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
       "dev": true
     },
+    "rxjs": {
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.5.tgz",
+      "integrity": "sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.0"
+      }
+    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
     "semantic-release": {
@@ -6104,6 +6744,25 @@
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true
     },
+    "slice-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
+        "is-fullwidth-code-point": "^2.0.0"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        }
+      }
+    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -6288,6 +6947,58 @@
         }
       }
     },
+    "table": {
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
+      "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.10.2",
+        "lodash": "^4.17.14",
+        "slice-ansi": "^2.1.0",
+        "string-width": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
     "temp-dir": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
@@ -6326,6 +7037,12 @@
       "integrity": "sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==",
       "dev": true
     },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -6339,6 +7056,15 @@
       "dev": true,
       "requires": {
         "readable-stream": "2 || 3"
+      }
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "~1.0.2"
       }
     },
     "to-regex-range": {
@@ -6368,11 +7094,31 @@
       "integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
       "dev": true
     },
+    "tslib": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+      "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
+      "dev": true
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2"
+      }
+    },
     "type-fest": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
       "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
       "dev": true
+    },
+    "uc.micro": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
     },
     "uglify-js": {
       "version": "3.8.0",
@@ -6409,6 +7155,15 @@
       "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
       "dev": true
     },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
     "url-join": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
@@ -6419,6 +7174,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "v8-compile-cache": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
+      "integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
       "dev": true
     },
     "validate-npm-package-license": {
@@ -6454,6 +7215,12 @@
       "requires": {
         "execa": "^1.0.0"
       }
+    },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
     },
     "wordwrap": {
       "version": "0.0.3",
@@ -6504,6 +7271,15 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
+    },
+    "write": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+      "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1"
+      }
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "@semantic-release/npm": "^7.0.3",
     "@semantic-release/release-notes-generator": "^9.0.1",
     "conventional-changelog-conventionalcommits": "^4.2.3",
-    "semantic-release": "^17.0.4",
-    "eslint": "^6.8.0"
+    "eslint": "^6.8.0",
+    "semantic-release": "^17.0.7"
   },
   "release": {
     "branches": [

--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
   "author": "Michael Davis <michael@damaru.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "lodash": "^4.17.15",
+    "@asyncapi/generator-filters": "^1.0.0",
     "js-yaml": "^3.13.1",
-    "@asyncapi/generator-filters": "https://github.com/derberg/generator-filters#use-filters-lib"
+    "lodash": "^4.17.15"
   },
   "devDependencies": {
     "@semantic-release/commit-analyzer": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "description": "Java Spring Cloud Stream template for AsyncAPI generator.",
   "scripts": {
     "release": "semantic-release",
+    "lint": "eslint --config .eslintrc .",
+    "lint-fix": "eslint --fix --config .eslintrc .",
     "get-version": "echo $npm_package_version"
   },
   "keywords": [
@@ -21,7 +23,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "lodash": "^4.17.15",
-    "js-yaml": "^3.13.1"
+    "js-yaml": "^3.13.1",
+    "@asyncapi/generator-filters": "https://github.com/derberg/generator-filters#use-filters-lib"
   },
   "devDependencies": {
     "@semantic-release/commit-analyzer": "^8.0.1",
@@ -29,7 +32,8 @@
     "@semantic-release/npm": "^7.0.3",
     "@semantic-release/release-notes-generator": "^9.0.1",
     "conventional-changelog-conventionalcommits": "^4.2.3",
-    "semantic-release": "^17.0.4"
+    "semantic-release": "^17.0.4",
+    "eslint": "^6.8.0"
   },
   "release": {
     "branches": [

--- a/template/src/main/java/Application.java
+++ b/template/src/main/java/Application.java
@@ -13,7 +13,7 @@ import org.springframework.messaging.Message;
 {%- if params.reactive === 'true' %}
 import reactor.core.publisher.Flux;
 {%- endif -%}
-{%- set funcs = [asyncapi, params] | functions -%}
+{%- set funcs = [asyncapi, params] | functionSpecs -%}
 {%- set hasFunctions = false -%}
 {%- set hasConsumers = false -%}
 {%- set hasSuppliers = false -%}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- use generic filters library
- modify and cleanup of local filters for new testable style
- removed filters that are already in the generator-filters
- I also added eslint that we use in asyncapi as there was a lot of code to handle and formatting was very hard. Check out the new scripts that you can use in future, there are some errors I did not dig into that could not be fixed by eslint automatically

It looks like a lot of changes, but don't worry, I did not touch the logic. Some filters are removed but only because they are available thanks to the new generator-filter library

**Related issue(s)**
See also https://github.com/asyncapi/generator/issues/212