### PR TITLE
feat: migrate to latest generator enabling usage of reusable hooks

### DIFF
--- a/.tp-config.json
+++ b/.tp-config.json
@@ -1,5 +1,5 @@
 {
-  "generator": ">=0.41.0 <2.0.0",
+  "generator": ">=0.46.0 <2.0.0",
   "parameters": {
     "actuator": {
       "description": "If present, it adds the dependencies for spring-boot-starter-web, spring-boot-starter-actuator and micrometer-registry-prometheus.",

--- a/hooks/post-process.js
+++ b/hooks/post-process.js
@@ -6,8 +6,8 @@ const ScsLib = require('../lib/scsLib.js');
 
 const sourceHead = '/src/main/java/';
 
-module.exports = register => {
-  register('generate:after', generator => {
+module.exports = {
+  'generate:after': generator => {
     const scsLib = new ScsLib();
     const asyncapi = generator.asyncapi;
     let sourcePath = generator.targetDir + sourceHead;
@@ -76,18 +76,17 @@ module.exports = register => {
     const schemas = asyncapi.components().schemas();
     //console.log("schemas: " + JSON.stringify(schemas));
 
-    for (let schema in schemas) {
+    for (const schema in schemas) {
       let javaName = _.camelCase(schema);
       javaName = _.upperFirst(javaName);
 
       if (javaName !== schema) {
-        let oldPath = path.resolve(sourcePath, schema + ".java");
-        let newPath = path.resolve(sourcePath, javaName + ".java");
+        const oldPath = path.resolve(sourcePath, `${schema  }.java`);
+        const newPath = path.resolve(sourcePath, `${javaName  }.java`);
         fs.renameSync(oldPath, newPath);
         // console.log("Renamed class file "  + schema + " to " + javaName);
       }
     }
-
 
     // This renames schema objects according to the title field. By default we won't do this, we might add this as an option.
 
@@ -109,6 +108,6 @@ module.exports = register => {
       }
     }
     */
-  });
+  }
 };
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- migrate to latest generator enabling usage of reusable hooks
- hooks functions refactor to new approach

Test by:
- installing latest generator `npm install @asyncapi/generator -g`
- generate using fork `ag asyncapi.yml https://github.com/derberg/java-spring-cloud-stream-template#refactor-hooks -o output --force-write`

What this change gives to template dev:
- write reusable hooks or just use hooks from official asyncapi library to DRY
  - https://github.com/asyncapi/generator/blob/master/docs/authoring.md#hooks
  - https://github.com/asyncapi/generator-hooks/#using-hooks-library-in-custom-template

**Related issue(s)**
See also https://github.com/asyncapi/generator/issues/318