### PR TITLE
fix for 'Channel <x>: no payload class has been defined'

### DIFF
--- a/filters/all.js
+++ b/filters/all.js
@@ -640,6 +640,10 @@ function getPayloadClass(pubOrSub) {
           ret = _.camelCase(ret);
           ret = _.upperFirst(ret);
         }
+      } else {
+        ret = pubOrSub._json.message.payload['x-parser-schema-id']
+        ret = _.camelCase(ret);
+        ret = _.upperFirst(ret);
       }
     }
   //console.log("getPayloadClass: " + ret);


### PR DESCRIPTION
**Description**

I tried asyncapi and had always trouble to generate code with this template and the current version of the generator (1.0.0-rc.5). I encountered this error:

> Error: Channel https://example.com/books/{id}: no payload class has been defined.

This is a quick fix for the problem.

Test async spec:

```
asyncapi: '2.0.0'
info:
  title: Mercure Hub Example
  version: '1.0.0'
  description: This example demonstrates how to define a Mercure hub.

# While not mandatory, it's a best practice to use formats with hypermedia capabilities such as JSON-LD, Atom or HTML with the Mercure protocol
defaultContentType: application/ld+json

servers:
  production:
    url: https://demo.mercure.rocks/.well-known/mercure
    protocol: mercure

channels:
  'https://example.com/books/{id}':
    description: Every time a resource of type `http://schema.org/Book` is created or modified, a JSON-LD representation of the new version of this resource must be pushed in this Mercure topic.
    parameters:
      id:
        schema:
          type: integer
    subscribe:
      message:
        $ref: '#/components/messages/book'      
    publish:
      message:
        $ref: '#/components/messages/book'

components:
  messages:
    book:
      summary: The content of a book resource.
      externalDocs:
        url: https://schema.org/Book
      payload:
        type: object
        properties:
          '@id':
            type: string
            format: iri-reference
          '@type':
            type: string
            format: iri-reference
          name:
            type: string
          isbn:
            type: string
          abstract:
            type: string
```