### PR TITLE
fix: Update Spring & Solace Versions

### DIFF
--- a/filters/all.js
+++ b/filters/all.js
@@ -5,10 +5,10 @@ const ScsLib = require('../lib/scsLib.js');
 const scsLib = new ScsLib();
 	
 // Library versions
-const SOLACE_SPRING_CLOUD_VERSION = '1.1.0';
-const SPRING_BOOT_VERSION = '2.3.1.RELEASE';
-const SPRING_CLOUD_VERSION = 'Hoxton.SR6';
-const SPRING_CLOUD_STREAM_VERSION = '3.0.6.RELEASE';
+const SOLACE_SPRING_CLOUD_VERSION = '1.1.1';
+const SPRING_BOOT_VERSION = '2.3.2.RELEASE';
+const SPRING_CLOUD_VERSION = 'Hoxton.SR7';
+const SPRING_CLOUD_STREAM_VERSION = '3.0.7.RELEASE';
 
 // Connection defaults. SOLACE_DEFAULT applies to msgVpn, username and password.
 const SOLACE_HOST = 'tcp://localhost:55555';


### PR DESCRIPTION
Update Versions: 
* Solace Binder had some important bug fixes as part of `solace-spring-cloud` v1.1.1 release
* Updated to latest Spring Boot, Spring Cloud & Cloud Stream while at it!  