### PR TITLE
fix: Remove duplicated Java reserved word

### DIFF
--- a/lib/scsLib.js
+++ b/lib/scsLib.js
@@ -84,7 +84,6 @@ ScsLib.reservedWords.add('abstract');
 ScsLib.reservedWords.add('assert');
 ScsLib.reservedWords.add('boolean');
 ScsLib.reservedWords.add('break');
-ScsLib.reservedWords.add('boolean');
 ScsLib.reservedWords.add('byte');
 ScsLib.reservedWords.add('case');
 ScsLib.reservedWords.add('catch');


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines and make sure PR title follows Conventional Commits specification -> https://github.com/asyncapi/generator/blob/master/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- Remove duplicated Java reserved word from `scsLib.js` file.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, othewise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The 3rd option will not automatically close the issue after the merge. -->
Fixes #62 