### PR TITLE
fix: inner Java classes weren't getting rendered

### DIFF
--- a/filters/all.js
+++ b/filters/all.js
@@ -304,6 +304,16 @@ function functionSpecs([asyncapi, params]) {
 }
 filter.functionSpecs = functionSpecs;
 
+// This returns the list of methods belonging to an object, just to help debugging.
+const getMethods = (obj) => {
+  const properties = new Set();
+  let currentObj = obj;
+  do {
+    Object.getOwnPropertyNames(currentObj).forEach(item => properties.add(item));
+  } while ((currentObj = Object.getPrototypeOf(currentObj)));
+  return [...properties.keys()].filter(item => typeof obj[item] === 'function');
+};
+
 function getRealPublisher([info, params, channel]) {
   const pub = scsLib.getRealPublisher(info, params, channel);
   return pub;
@@ -321,15 +331,14 @@ function groupId([info, params]) {
 }
 filter.groupId = groupId;
 
-// This returns the list of methods belonging to an object, just to help debugging.
-const getMethods = (obj) => {
-  const properties = new Set();
-  let currentObj = obj;
-  do {
-    Object.getOwnPropertyNames(currentObj).forEach(item => properties.add(item));
-  } while ((currentObj = Object.getPrototypeOf(currentObj)));
-  return [...properties.keys()].filter(item => typeof obj[item] === 'function');
-};
+function isEmpty(obj) {
+
+  if (!obj) {
+    return false;
+  }
+  return obj && Object.keys(obj).length === 0 && obj.constructor === Object;
+}
+filter.isEmpty = isEmpty;
 
 function logFull(obj) {
   console.log(obj);

--- a/filters/all.js
+++ b/filters/all.js
@@ -341,6 +341,11 @@ function logFull(obj) {
 }
 filter.logFull = logFull;
 
+function logIt(obj) {
+  console.log(obj);
+}
+filter.logIt = logIt;
+
 function lowerFirst(str) {
   return _.lowerFirst(str);
 }

--- a/filters/all.js
+++ b/filters/all.js
@@ -332,9 +332,8 @@ function groupId([info, params]) {
 filter.groupId = groupId;
 
 function isEmpty(obj) {
-
   if (!obj) {
-    return false;
+    return true;
   }
   return obj && Object.keys(obj).length === 0 && obj.constructor === Object;
 }
@@ -349,11 +348,6 @@ function logFull(obj) {
   return obj;
 }
 filter.logFull = logFull;
-
-function logIt(obj) {
-  console.log(obj);
-}
-filter.logIt = logIt;
 
 function lowerFirst(str) {
   return _.lowerFirst(str);

--- a/partials/java-class
+++ b/partials/java-class
@@ -76,9 +76,6 @@
 {%- if prop.type() === 'object' %}
 {{ javaClass(javaName, null, prop.properties(), prop.required(), indentLevel+1, true) }}
 {% endif -%}
-{%- if prop.type === 'object' %}
-{{ javaClass(javaName, null, prop.properties, prop.required, indentLevel+1, true) }}
-{% endif -%}
 {%- if isArrayOfObjects %}
 {{ javaClass(javaName, null, prop.items().properties(), prop.items().required(), indentLevel+1, true) }}
 {% endif -%}

--- a/partials/java-class
+++ b/partials/java-class
@@ -25,6 +25,8 @@
 {%- else -%} {# not an array at the top level. #}
 {%- set first = true -%}
 {#- Constructor with all properties -#}
+{%- set hasNoProperties = properties | isEmpty -%}
+{%- if not hasNoProperties -%}
 {{ indent2 }}public {{ className }} (
 {%- for name, prop in properties -%}
 {%- set javaName = name | identifierName -%}
@@ -42,6 +44,7 @@
 {{ indent3 }}this.{{ javaName }} = {{ javaName }};
 {% endfor -%}
 {{ indent2 }}}
+{% endif -%}
 {% endif -%}
 
 {# Members #}

--- a/partials/java-class
+++ b/partials/java-class
@@ -70,10 +70,10 @@
 {{ indent3 }}return this;
 {{ indent2 }}}
 {# Inner classes #}
-{%- if indentLevel == 0 and  prop.type() === 'object' %}
+{%- if prop.type() === 'object' %}
 {{ javaClass(javaName, null, prop.properties(), prop.required(), indentLevel+1, true) }}
 {% endif -%}
-{%- if indentLevel > 0 and prop.type === 'object' %}
+{%- if prop.type === 'object' %}
 {{ javaClass(javaName, null, prop.properties, prop.required, indentLevel+1, true) }}
 {% endif -%}
 {%- if isArrayOfObjects %}


### PR DESCRIPTION
**Description**
This fixes a bug where inner Java classes weren't getting rendered. Also, usually it creates 2 constructors per schema class, but now it won't if the class has no properties.

**Related issue(s)**
Fixes #103
