### PR TITLE
fix: arrays of non-object types were not getting rendered properly.

### DIFF
--- a/filters/all.js
+++ b/filters/all.js
@@ -262,13 +262,12 @@ function fixType([name, javaName, property]) {
       throw new Error(`Array named ${  name  } must have an 'items' property to indicate what type the array elements are.`);
     }
     let itemsType = property.items().type();
-
     if (itemsType) {
       if (itemsType === 'object') {
         isArrayOfObjects = true;
         itemsType = _.upperFirst(javaName);
       } else {
-        itemsType = typeMap.get(itemsType);
+        itemsType = getType(itemsType, format).javaType;
       }
     }
     if (!itemsType) {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines and make sure PR title follows Conventional Commits specification -> https://github.com/asyncapi/generator/blob/master/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**
When rendering a property that was an array of string (or anything not an object), it would be rendered incorrectly, something like [Object][] instead of String[].

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, othewise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The 3rd option will not automatically close the issue after the merge. -->
Fixes #92