### PR TITLE
fix: generated code examples are now commented out.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ There are two specification extentions you can use to shape how the bindings are
 
 ```x-scs-group``` : This will add the group value on a binding which configures your microservice to use [Consumer Groups](https://cloud.spring.io/spring-cloud-static/spring-cloud-stream/current/reference/html/spring-cloud-stream.html#consumer-groups)
 
+### Limitations
+Currently any schemas that are used must be in the components/schemas part of the document. We do not support anonymous object-type schemas in the message/payload sections.
+
 ### Parameters
 
 Parameters can be passed to the generator using command line arguments in the form ```-p param=value -p param2=value2```. Here is a list of the parameters that can be used with this template. In some cases these can be put into the AsyncAPI documents using the specification extensions feature. In those cases, the 'info' prefix means that it belongs in the info section of the document.

--- a/template/src/main/java/Application.java
+++ b/template/src/main/java/Application.java
@@ -4,21 +4,11 @@
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-{% if extraIncludes.dynamicTopics %}
-import org.springframework.beans.factory.annotation.Autowired;
-{% endif %}
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-{% if extraIncludes.dynamicTopics %}
-import org.springframework.cloud.stream.binder.BinderHeaders;
-import org.springframework.cloud.stream.function.StreamBridge;
-{% endif %}
 import org.springframework.context.annotation.Bean;
-{% if extraIncludes.dynamicTopics or extraIncludes.needMessageInclude %}
+{% if extraIncludes.needMessageInclude %}
 import org.springframework.messaging.Message;
-{% endif %}
-{% if extraIncludes.dynamicTopics %}
-import org.springframework.messaging.support.MessageBuilder;
 {% endif %}
 {%- if params.reactive === 'true' %}
 import reactor.core.publisher.Flux;
@@ -47,18 +37,32 @@ import java.util.function.Consumer;
 {%- if hasSuppliers %}
 import java.util.function.Supplier;
 {%- endif %}
+{% if extraIncludes.dynamicTopics %}
+// Uncomment this if you want to use one of the sample functions commented out below.
+/*
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.stream.binder.BinderHeaders;
+import org.springframework.cloud.stream.function.StreamBridge;
+{%- if extraIncludes.dynamicTopics and not extraIncludes.needMessageInclude %}
+import org.springframework.messaging.Message;
+{%- endif %}
+import org.springframework.messaging.support.MessageBuilder;
+*/
+{% endif %}
 
 {% set className = [asyncapi.info(), params] | mainClassName %}
 @SpringBootApplication
 public class {{ className }} {
-	{%- if dynamicFuncs.size %}
-private static final String DYNAMIC_BINDING = "dynamic";
+
+    private static final Logger logger = LoggerFactory.getLogger({{ className }}.class);
+{%- if dynamicFuncs.size %}
+//Uncomment this if you want to use one of the sample functions commented out below.
+/*
+    private static final String DYNAMIC_BINDING = "dynamic";
+    @Autowired
+    private StreamBridge streamBridge;
+*/
 {%- endif %}
-private static final Logger logger = LoggerFactory.getLogger({{ className }}.class);
-	{%- if dynamicFuncs.size %}
-@Autowired
-private StreamBridge streamBridge;
-	{%- endif %}
 
 	public static void main(String[] args) {
 		SpringApplication.run({{ className }}.class);
@@ -71,6 +75,8 @@ private StreamBridge streamBridge;
 	}
 {%- endfor %}
 
+{% if dynamicFuncs.size %}
+/* Here is an example of how to send a message to a dynamic topic:
 {% for dynFuncName, dynFuncSpec in dynamicFuncs %}
 	public void {{ dynFuncName }}(
 		{{ dynFuncSpec.payloadClass }} payload, {{ dynFuncSpec.topicInfo.functionParamList }}
@@ -84,5 +90,6 @@ private StreamBridge streamBridge;
 		streamBridge.send(DYNAMIC_BINDING, message);
 	}
 {%- endfor %}
-
+*/
+{%- endif %}
 }


### PR DESCRIPTION
**Description**
When we generate code that publishes to a topic with parameters, we generate two functions, the standard Supplier, and also a custom function that constructs the topic and sends it via the StreamBridge.

Early feedback from users was that having both functions was confusing, and they asked to comment out the custom function, leaving it as an example in case people wanted to use it.

**Related issue(s)**
Fixes #128 
