### PR TITLE
fix: fixType for arrays no longer forces case from the typeMap's javaType

### DIFF
--- a/filters/all.js
+++ b/filters/all.js
@@ -283,7 +283,7 @@ function fixType([name, javaName, property]) {
         throw new Error(`Array named ${  name  }: can't determine the type of the items.`);
       }
     }
-    typeName = `${_.upperFirst(itemsType)  }[]`;
+    typeName = `${itemsType}[]`;
   } else if (type === 'object') {
     typeName = _.upperFirst(javaName);
   } else if (property.enum()) {


### PR DESCRIPTION

**Description**

I came into an issue where number arrays in an object were typed as `Java.math.BigDecimal[]` and looked at the `fixType` filter.
It appears that the `itemsType` variable is either already upperFirst or from the static typeMap so there's no need to further change its case.


Test specification
```yml
asyncapi: 2.0.0
id: "urn:fixArrayTypes"
defaultContentType: application/json
info:
    title: FixArrayTypes
    version: 0.1.0
channels:
    myChannel:
        publish:
            operationId: send
            summary: Information about changes on an order
            message:
                description: An event
                payload:
                    $ref: "#/components/schemas/wrapped"
components:
    schemas:
        wrapped:
            title: wrapped array
            type: object
            properties:
                myArray:
                    type: array
                    items:
                        type: number
```
- [before.zip](https://github.com/asyncapi/java-spring-cloud-stream-template/files/6886729/before.zip)
- [after.zip](https://github.com/asyncapi/java-spring-cloud-stream-template/files/6886728/after.zip)
