### PR TITLE
feat: add a comment to methods listing which message types they use

### DIFF
--- a/template/src/main/java/Application.java
+++ b/template/src/main/java/Application.java
@@ -99,6 +99,9 @@ public class {{ className }} {
 	}
 		{%- endif %}
 	{%- elif funcSpec.type === 'consumer' %}
+		{%- if funcSpec.multipleMessageComment %}
+	{{ funcSpec.multipleMessageComment }}
+		{%- endif %}
 	@Bean
 	{{ funcSpec.functionSignature | safe }} {
 		return data -> {
@@ -108,7 +111,7 @@ public class {{ className }} {
 	}	
 	{%- else %}{#- it is a supplier. #}
 		{%- if funcSpec.dynamic %}
-			{%- if params.dynamicType === 'header' %}
+			{%- if params.dynamicType === 'header' -%}
 	@Bean
 	{{ funcSpec.functionSignature | safe }} {
 		return () -> {
@@ -130,6 +133,9 @@ public class {{ className }} {
 			{# else do nothing, we just use the void function below. #}
 			{%- endif %}{# dynamic type #}
 		{%- else -%}{# it is not dynamic. #}
+			{%- if funcSpec.multipleMessageComment %}
+	{{ funcSpec.multipleMessageComment }}
+			{%- endif %}
 	@Bean
 	{{ funcSpec.functionSignature | safe }} {
 		return () -> {

--- a/test/__snapshots__/integration.test.js.snap
+++ b/test/__snapshots__/integration.test.js.snap
@@ -1,5 +1,52 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`template integration tests using the generator should generate a comment for a consumer receiving multiple messages 1`] = `
+"
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.messaging.Message;
+
+@SpringBootApplication
+public class Application {
+
+	private static final Logger logger = LoggerFactory.getLogger(Application.class);
+
+	public static void main(String[] args) {
+		SpringApplication.run(Application.class);
+	}
+
+	// The message can be of type:
+	// Cat
+	// Dog
+	@Bean
+	public Supplier<Message<?>> animalsSupplier() {
+		return () -> {
+			// Add business logic here.
+			return new Message<?>();
+		};
+	}
+
+	// The message can be of type:
+	// Cat
+	// Dog
+	@Bean
+	public Consumer<Message<?>> animalsConsumer() {
+		return data -> {
+			// Add business logic here.	
+			logger.info(data.toString());
+		};
+	}
+
+}
+"
+`;
+
 exports[`template integration tests using the generator should generate application files using the solace binder 1`] = `
 "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
 <project xmlns=\\"http://maven.apache.org/POM/4.0.0\\" xmlns:xsi=\\"http://www.w3.org/2001/XMLSchema-instance\\" xsi:schemaLocation=\\"http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd\\">

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -85,4 +85,19 @@ describe('template integration tests using the generator', () => {
       expect(file).toMatchSnapshot();
     }
   });
+
+  it('should generate a comment for a consumer receiving multiple messages', async () => {
+    const OUTPUT_DIR = generateFolderName();
+    
+    const generator = new Generator(path.normalize('./'), OUTPUT_DIR, { forceWrite: true });
+    await generator.generateFromFile(path.resolve('test', 'mocks/animals.yaml'));
+
+    const expectedFiles = [
+      'src/main/java/Application.java'
+    ];
+    for (const index in expectedFiles) {
+      const file = await readFile(path.join(OUTPUT_DIR, expectedFiles[index]), 'utf8');
+      expect(file).toMatchSnapshot();
+    }
+  });
 });

--- a/test/mocks/animals.yaml
+++ b/test/mocks/animals.yaml
@@ -1,0 +1,36 @@
+components:
+  schemas:
+    Dog:
+      type: object
+      properties:
+        name: 
+          type: string
+    Cat:
+      type: object
+      properties:
+        name: 
+          type: string
+  messages:
+    DogMessage:
+      payload:
+        $ref: '#/components/schemas/Dog'
+    CatMessage:
+      payload:
+        $ref: '#/components/schemas/Cat'
+channels:
+  'animals':
+    publish:
+      message:
+        oneOf:
+        - $ref: '#/components/messages/CatMessage'
+        - $ref: '#/components/messages/DogMessage'
+    subscribe:
+      message:
+        oneOf:
+        - $ref: '#/components/messages/CatMessage'
+        - $ref: '#/components/messages/DogMessage'
+asyncapi: 2.0.0
+info:
+  description: Testing oneOf
+  title: animals
+  version: 0.0.1


### PR DESCRIPTION
**Description**

When an operation has a 'oneOf' keyword to work with multiple kinds of messages, it would be nice to have a comment that lists the kinds of messages.

**Related issue(s)**
Resolves #162