### PR TITLE
fix: unable to get model class when using arrays in schema

### DIFF
--- a/filters/all.js
+++ b/filters/all.js
@@ -423,8 +423,8 @@ const getMethods = (obj) => {
   return [...properties.keys()].filter(item => typeof obj[item] === 'function');
 };
 
-function getModelClass(schemaName) {
-  return applicationModel.getModelClass(schemaName);
+function getModelClass(customSchemaObject) {
+  return applicationModel.getModelClass(customSchemaObject);
 }
 
 filter.getModelClass = getModelClass;

--- a/filters/all.js
+++ b/filters/all.js
@@ -429,7 +429,7 @@ function getModelClass(customSchemaObject) {
 filter.getModelClass = getModelClass;
 
 function getAnonymousSchemaForRef(schemaName) {
-	return applicationModel.getAnonymousSchemaForRef(schemaName);
+  return applicationModel.getAnonymousSchemaForRef(schemaName);
 }
 filter.getAnonymousSchemaForRef = getAnonymousSchemaForRef;
 

--- a/filters/all.js
+++ b/filters/all.js
@@ -426,8 +426,12 @@ const getMethods = (obj) => {
 function getModelClass(customSchemaObject) {
   return applicationModel.getModelClass(customSchemaObject);
 }
-
 filter.getModelClass = getModelClass;
+
+function getAnonymousSchemaForRef(schemaName) {
+	return applicationModel.getAnonymousSchemaForRef(schemaName);
+}
+filter.getAnonymousSchemaForRef = getAnonymousSchemaForRef;
 
 function getRealPublisher([info, params, channel]) {
   return scsLib.getRealPublisher(info, params, channel);

--- a/hooks/post-process.js
+++ b/hooks/post-process.js
@@ -75,11 +75,13 @@ function processSchema(generator, schemaName, schema, sourcePath, defaultJavaPac
   const filePath = path.resolve(sourcePath, fileName);
   debugPostProcess(`processSchema ${schemaName}`);
   debugPostProcess(schema);
-  const modelClass = applicationModel.getModelClass({schema: schema, schemaName: schemaName});
+  const modelClass = applicationModel.getModelClass({schema, schemaName});
   const javaName = modelClass.getClassName();
   if ((schema.type() && schema.type() !== 'object') || _.startsWith(javaName, 'Anonymous')) {
     debugPostProcess(`deleting ${filePath}`);
-    fs.existsSync(filePath) && fs.unlinkSync(filePath);
+    if (fs.existsSync(filePath)) {
+      fs.unlinkSync(filePath);
+    }
   } else {
     const packageDir = getPackageDir(generator, defaultJavaPackageDir, modelClass);
     debugPostProcess(`packageDir: ${packageDir}`);

--- a/hooks/post-process.js
+++ b/hooks/post-process.js
@@ -77,7 +77,7 @@ function processSchema(generator, schemaName, schema, sourcePath, defaultJavaPac
   debugPostProcess(schema);
   const modelClass = applicationModel.getModelClass({schema: schema, schemaName: schemaName});
   const javaName = modelClass.getClassName();
-  if (schema.type() !== 'object' || _.startsWith(javaName, 'Anonymous')) {
+  if ((schema.type() && schema.type() !== 'object') || _.startsWith(javaName, 'Anonymous')) {
     debugPostProcess(`deleting ${filePath}`);
     fs.existsSync(filePath) && fs.unlinkSync(filePath);
   } else {

--- a/hooks/post-process.js
+++ b/hooks/post-process.js
@@ -2,6 +2,7 @@
 const fs = require('fs');
 const path = require('path');
 const ApplicationModel = require('../lib/applicationModel.js');
+const _ = require('lodash');
 const applicationModel = new ApplicationModel('post');
 // To enable debug logging, set the env var DEBUG="postProcess" with whatever things you want to see.
 const debugPostProcess = require('debug')('postProcess');
@@ -74,12 +75,12 @@ function processSchema(generator, schemaName, schema, sourcePath, defaultJavaPac
   const filePath = path.resolve(sourcePath, fileName);
   debugPostProcess(`processSchema ${schemaName}`);
   debugPostProcess(schema);
-  if (schema.type() !== 'object') {
+  const modelClass = applicationModel.getModelClass({schema: schema, schemaName: schemaName});
+  const javaName = modelClass.getClassName();
+  if (schema.type() !== 'object' || _.startsWith(javaName, 'Anonymous')) {
     debugPostProcess(`deleting ${filePath}`);
-    fs.unlinkSync(filePath);
+    fs.existsSync(filePath) && fs.unlinkSync(filePath);
   } else {
-    const modelClass = applicationModel.getModelClass(schemaName);
-    const javaName = modelClass.getClassName();
     const packageDir = getPackageDir(generator, defaultJavaPackageDir, modelClass);
     debugPostProcess(`packageDir: ${packageDir}`);
 

--- a/lib/applicationModel.js
+++ b/lib/applicationModel.js
@@ -17,7 +17,7 @@ class ApplicationModel {
     this.setupModelClassMap();
     let modelClass;
     if (schema) {
-      let parserSchemaName = schema.ext('x-parser-schema-id');
+      const parserSchemaName = schema.ext('x-parser-schema-id');
       // Try to use x-parser-schema-id as key
       modelClass = this.modelClassMap[parserSchemaName];
       if (modelClass && _.startsWith(modelClass.getClassName(), 'Anonymous')) {
@@ -123,7 +123,7 @@ class ApplicationModel {
       // Each property name is the name of a schema. It should also have an x-parser-schema-id name. We'll be adding duplicate mappings (two mappings to the same model class) since the anon schemas do have names
       Object.keys(schema.properties()).forEach(property => {
         const innerSchema = schema.properties()[property];
-        const innerSchemaParserId = innerSchema.ext("x-parser-schema-id");
+        const innerSchemaParserId = innerSchema.ext('x-parser-schema-id');
         const existingModelClass = this.modelClassMap[innerSchemaParserId];
         if (existingModelClass) {
           this.modelClassMap[property] = existingModelClass;
@@ -147,13 +147,13 @@ class ApplicationModel {
     if (this.isAnonymousSchema(schemaName)) {
       this.handleAnonymousSchemaForAllOf(modelClass, schemaName);
     }
-
-    const nonInnerClassSchemas = Object.keys(ApplicationModel.asyncapi._json.components?.schemas || {});
+    const components = ApplicationModel.asyncapi._json.components;
+    const nonInnerClassSchemas = Object.keys(components? components.schemas || {} : {});
     if (nonInnerClassSchemas.includes(schemaName)) {
       modelClass.setCanBeInnerClass(false);
     }
 
-    let { className, javaPackage } = this.stripPackageName(schemaName);
+    const { className, javaPackage } = this.stripPackageName(schemaName);
     modelClass.setJavaPackage(javaPackage);
     modelClass.setClassName(className);
     debugApplicationModel(`schemaName ${schemaName} className: ${modelClass.getClassName()} super: ${modelClass.getSuperClassName()} javaPackage: ${javaPackage}`);

--- a/lib/applicationModel.js
+++ b/lib/applicationModel.js
@@ -165,10 +165,7 @@ class ApplicationModel {
   getAnonymousSchemaForRef(realSchemaName) {
     // During our allOf parsing, we found this real schema to anon-schema association
     const anonSchema = this.anonymousSchemaToSubClassMap[realSchemaName];
-    if (anonSchema) {
-      return this.nameToSchemaMap[anonSchema];
-    }  
-    return undefined;
+    return anonSchema ? this.nameToSchemaMap[anonSchema] : undefined;
   }
 
   handleAnonymousSchemaForAllOf(modelClass, schemaName) {

--- a/lib/applicationModel.js
+++ b/lib/applicationModel.js
@@ -1,5 +1,6 @@
 const ModelClass = require('./modelClass.js');
 const debugApplicationModel = require('debug')('applicationModel');
+const _ = require('lodash');
 const instanceMap = new Map();
 
 class ApplicationModel {
@@ -10,12 +11,22 @@ class ApplicationModel {
     debugApplicationModel(instanceMap);
   }
 
-  getModelClass(schemaName) {
+  getModelClass({schema, schemaName}) {
     debugApplicationModel(`getModelClass for caller ${this.caller} schema ${schemaName}`);
     this.setupSuperClassMap();
     this.setupModelClassMap();
-    const modelClass = this.modelClassMap[schemaName];
-    debugApplicationModel(`returning modelClass for  caller ${this.caller} ${schemaName}`);
+    let modelClass;
+    if (schema && schema._json) {
+      let parserSchemaName = schema._json['x-parser-schema-id'];
+      modelClass = this.modelClassMap[parserSchemaName];
+      if (modelClass && _.startsWith(modelClass.getClassName(), 'Anonymous')) {
+        modelClass.setClassName(_.upperFirst(this.isAnonymousSchema(parserSchemaName) ? schemaName : parserSchemaName));
+      }
+    }
+    if (!modelClass){
+      modelClass = this.modelClassMap[schemaName];
+    }
+    debugApplicationModel(`returning modelClass for caller ${this.caller} ${schemaName}`);
     debugApplicationModel(modelClass);
     return modelClass;
   }

--- a/lib/applicationModel.js
+++ b/lib/applicationModel.js
@@ -90,14 +90,15 @@ class ApplicationModel {
     if (!this.modelClassMap) {
       this.modelClassMap = new Map();
       this.nameToSchemaMap = new Map();
+      // Register all schemas first, then check the anonymous schemas for duplicates
       ApplicationModel.asyncapi.allSchemas().forEach((schema, name) => {
+        debugApplicationModel(`setupModelClassMap ${name} type ${schema.type()}`);
         this.registerSchemaNameToModelClass(schema, name);
         this.nameToSchemaMap[name] = schema;
       });
 
       ApplicationModel.asyncapi.allSchemas().forEach((schema, schemaName) => {
-        // debugApplicationModel(`setupModelClassMap ${schemaName} type ${schema.type()}`);
-
+        debugApplicationModel(`setupModelClassMap anonymous schemas ${schemaName} type ${schema.type()}`);
         this.checkProperties(schema);
 
         const allOf = schema.allOf();
@@ -112,8 +113,8 @@ class ApplicationModel {
           });
         }
       });
-      // debugApplicationModel('modelClassMap:');
-      // debugApplicationModel(this.modelClassMap);
+      debugApplicationModel('modelClassMap:');
+      debugApplicationModel(this.modelClassMap);
     }
   }
 
@@ -139,22 +140,23 @@ class ApplicationModel {
 
   registerSchemaNameToModelClass(schema, schemaName) {
     let modelClass = this.modelClassMap[schemaName];
-    if (!this.modelClassMap[schemaName]) {
+    if (!modelClass) {
       modelClass = new ModelClass();
     }
 
-    let tentativeClassName = schemaName;
     if (this.isAnonymousSchema(schemaName)) {
-      tentativeClassName = this.handleAnonymousSchemaForAllOf(modelClass, schemaName);
+      this.handleAnonymousSchemaForAllOf(modelClass, schemaName);
     }
-    tentativeClassName = this.stripPackageName(modelClass, schemaName);
 
     const nonInnerClassSchemas = Object.keys(ApplicationModel.asyncapi._json.components?.schemas || {});
     if (nonInnerClassSchemas.includes(schemaName)) {
       modelClass.setCanBeInnerClass(false);
     }
-    modelClass.setClassName(tentativeClassName);
-    // debugApplicationModel(`schemaName ${schemaName} className: ${modelClass.getClassName()} super: ${modelClass.getSuperClassName()} javaPackage: ${javaPackage}`);
+
+    let { className, javaPackage } = this.stripPackageName(schemaName);
+    modelClass.setJavaPackage(javaPackage);
+    modelClass.setClassName(className);
+    debugApplicationModel(`schemaName ${schemaName} className: ${modelClass.getClassName()} super: ${modelClass.getSuperClassName()} javaPackage: ${javaPackage}`);
     this.modelClassMap[schemaName] = modelClass;
     debugApplicationModel(`Added ${schemaName}`);
     debugApplicationModel(modelClass);
@@ -164,8 +166,7 @@ class ApplicationModel {
     // During our allOf parsing, we found this real schema to anon-schema association
     const anonSchema = this.anonymousSchemaToSubClassMap[realSchemaName];
     if (anonSchema) {
-      const foundSchema = this.nameToSchemaMap[anonSchema]    
-      return foundSchema;
+      return this.nameToSchemaMap[anonSchema];
     }  
     return undefined;
   }
@@ -174,8 +175,8 @@ class ApplicationModel {
     const subclassName = this.anonymousSchemaToSubClassMap[schemaName];
     if (subclassName) {
       modelClass.setSuperClassName(this.superClassMap[schemaName]);
-      // If we make it here, we need to be sure that the anonymous modelClass and the named modelClass is updated with the superclass information
-      // We dont want the anonymous schema because the class name won't be correct if it's a $ref, so if the modelClass exists, update that one, if it doesn't we're making it now
+      // Be sure the anonymous modelClass and the named modelClass are updated with the superclass information
+      // We dont want the anonymous schema because the class name won't be correct if it's a $ref, so if the modelClass exists, update that one, if it doesn't we'll make it
       const existingModelClass = this.modelClassMap[subclassName];
       if (existingModelClass) {
         existingModelClass.setSuperClassName(this.superClassMap[schemaName]);
@@ -186,15 +187,13 @@ class ApplicationModel {
     return schemaName;
   }
 
-  stripPackageName(modelClass, schemaName) {
+  stripPackageName(schemaName) {
     // If there is a dot in the schema name, it's probably an Avro schema with a fully qualified name (including the namespace.)
     const indexOfDot = schemaName.lastIndexOf('.');
     if (indexOfDot > 0) {
-      const javaPackage = schemaName.substring(0, indexOfDot);
-      modelClass.setJavaPackage(javaPackage);
-      return schemaName.substring(indexOfDot + 1);
+      return { className: schemaName.substring(indexOfDot + 1), javaPackage: schemaName.substring(0, indexOfDot) };
     }
-    return schemaName;
+    return { className: schemaName, javaPackage: undefined };
   }
 
   reset() {

--- a/lib/applicationModel.js
+++ b/lib/applicationModel.js
@@ -16,14 +16,18 @@ class ApplicationModel {
     this.setupSuperClassMap();
     this.setupModelClassMap();
     let modelClass;
-    if (schema && schema._json) {
-      let parserSchemaName = schema._json['x-parser-schema-id'];
+    if (schema) {
+      let parserSchemaName = schema.ext('x-parser-schema-id');
+      // Try to use x-parser-schema-id as key
       modelClass = this.modelClassMap[parserSchemaName];
       if (modelClass && _.startsWith(modelClass.getClassName(), 'Anonymous')) {
+        // If we translated this schema from the map using an anonymous schema key, we have no idea what the name should be, so we use the one provided directly from the source - not the generator.
+        // If we translated this schema from the map using a known schema (the name of the schema was picked out correctly by the generator), use that name.
         modelClass.setClassName(_.upperFirst(this.isAnonymousSchema(parserSchemaName) ? schemaName : parserSchemaName));
       }
     }
-    if (!modelClass){
+    // Using x-parser-schema-id didn't work for us, fall back to trying to get at least something using the provided name.
+    if (!modelClass) {
       modelClass = this.modelClassMap[schemaName];
     }
     debugApplicationModel(`returning modelClass for caller ${this.caller} ${schemaName}`);
@@ -77,30 +81,55 @@ class ApplicationModel {
     } else {
       this.superClassMap[anonymousSchema] = namedSchema;
       this.anonymousSchemaToSubClassMap[anonymousSchema] = schemaName;
+      this.superClassMap[schemaName] = namedSchema;
+      this.anonymousSchemaToSubClassMap[schemaName] = anonymousSchema;
     }
   }  
 
   setupModelClassMap() {
     if (!this.modelClassMap) {
       this.modelClassMap = new Map();
+      this.nameToSchemaMap = new Map();
+      ApplicationModel.asyncapi.allSchemas().forEach((schema, name) => {
+        this.registerSchemaNameToModelClass(schema, name);
+        this.nameToSchemaMap[name] = schema;
+      });
+
       ApplicationModel.asyncapi.allSchemas().forEach((schema, schemaName) => {
-        debugApplicationModel(`setupModelClassMap ${schemaName} type ${schema.type()}`);
+        // debugApplicationModel(`setupModelClassMap ${schemaName} type ${schema.type()}`);
+
+        this.checkProperties(schema);
+
         const allOf = schema.allOf();
         debugApplicationModel('allOf:');
         debugApplicationModel(allOf);
         if (allOf) {
           allOf.forEach(innerSchema => {
-            const name = innerSchema._json['x-parser-schema-id'];
+            const name = innerSchema.ext('x-parser-schema-id');
             if (this.isAnonymousSchema(name) && innerSchema.type() === 'object') {
-              this.addSchemaToMap(innerSchema, schemaName);
+              this.registerSchemaNameToModelClass(innerSchema, schemaName);
             }
           });
-        } else {
-          this.addSchemaToMap(schema, schemaName);
         }
       });
-      debugApplicationModel('modelClassMap:');
-      debugApplicationModel(this.modelClassMap);
+      // debugApplicationModel('modelClassMap:');
+      // debugApplicationModel(this.modelClassMap);
+    }
+  }
+
+  checkProperties(schema) {
+    if (!!Object.keys(schema.properties()).length) {
+      // Each property name is the name of a schema. It should also have an x-parser-schema-id name. We'll be adding duplicate mappings (two mappings to the same model class) since the anon schemas do have names
+      Object.keys(schema.properties()).forEach(property => {
+        const innerSchema = schema.properties()[property];
+        const innerSchemaParserId = innerSchema.ext("x-parser-schema-id");
+        const existingModelClass = this.modelClassMap[innerSchemaParserId];
+        if (existingModelClass) {
+          this.modelClassMap[property] = existingModelClass;
+        } else {
+          this.registerSchemaNameToModelClass(innerSchema, property);
+        }
+      });
     }
   }
 
@@ -108,30 +137,64 @@ class ApplicationModel {
     return schemaName.startsWith('<');
   }
 
-  addSchemaToMap(schema, schemaName) {
-    const modelClass = new ModelClass();
+  registerSchemaNameToModelClass(schema, schemaName) {
+    let modelClass = this.modelClassMap[schemaName];
+    if (!this.modelClassMap[schemaName]) {
+      modelClass = new ModelClass();
+    }
+
     let tentativeClassName = schemaName;
     if (this.isAnonymousSchema(schemaName)) {
-      // It's an anonymous schema. It might be a subclass...
-      const subclassName = this.anonymousSchemaToSubClassMap[schemaName];
-      if (subclassName) {
-        tentativeClassName = subclassName;
-        modelClass.setSuperClassName(this.superClassMap[schemaName]);
-      }
+      tentativeClassName = this.handleAnonymousSchemaForAllOf(modelClass, schemaName);
     }
-    // If there is a dot in the schema name, it's probably an Avro schema with a fully qualified name (including the namespace.)
-    const indexOfDot = schemaName.lastIndexOf('.');
-    let javaPackage;
-    if (indexOfDot > 0) {
-      javaPackage = schemaName.substring(0, indexOfDot);
-      tentativeClassName = schemaName.substring(indexOfDot + 1);
-      modelClass.setJavaPackage(javaPackage);
+    tentativeClassName = this.stripPackageName(modelClass, schemaName);
+
+    const nonInnerClassSchemas = Object.keys(ApplicationModel.asyncapi._json.components?.schemas || {});
+    if (nonInnerClassSchemas.includes(schemaName)) {
+      modelClass.setCanBeInnerClass(false);
     }
     modelClass.setClassName(tentativeClassName);
-    debugApplicationModel(`schemaName ${schemaName} className: ${modelClass.getClassName()} super: ${modelClass.getSuperClassName()} javaPackage: ${javaPackage}`);
+    // debugApplicationModel(`schemaName ${schemaName} className: ${modelClass.getClassName()} super: ${modelClass.getSuperClassName()} javaPackage: ${javaPackage}`);
     this.modelClassMap[schemaName] = modelClass;
     debugApplicationModel(`Added ${schemaName}`);
     debugApplicationModel(modelClass);
+  }
+
+  getAnonymousSchemaForRef(realSchemaName) {
+    // During our allOf parsing, we found this real schema to anon-schema association
+    const anonSchema = this.anonymousSchemaToSubClassMap[realSchemaName];
+    if (anonSchema) {
+      const foundSchema = this.nameToSchemaMap[anonSchema]    
+      return foundSchema;
+    }  
+    return undefined;
+  }
+
+  handleAnonymousSchemaForAllOf(modelClass, schemaName) {
+    const subclassName = this.anonymousSchemaToSubClassMap[schemaName];
+    if (subclassName) {
+      modelClass.setSuperClassName(this.superClassMap[schemaName]);
+      // If we make it here, we need to be sure that the anonymous modelClass and the named modelClass is updated with the superclass information
+      // We dont want the anonymous schema because the class name won't be correct if it's a $ref, so if the modelClass exists, update that one, if it doesn't we're making it now
+      const existingModelClass = this.modelClassMap[subclassName];
+      if (existingModelClass) {
+        existingModelClass.setSuperClassName(this.superClassMap[schemaName]);
+        modelClass = existingModelClass;
+      }
+      return subclassName;
+    }
+    return schemaName;
+  }
+
+  stripPackageName(modelClass, schemaName) {
+    // If there is a dot in the schema name, it's probably an Avro schema with a fully qualified name (including the namespace.)
+    const indexOfDot = schemaName.lastIndexOf('.');
+    if (indexOfDot > 0) {
+      const javaPackage = schemaName.substring(0, indexOfDot);
+      modelClass.setJavaPackage(javaPackage);
+      return schemaName.substring(indexOfDot + 1);
+    }
+    return schemaName;
   }
 
   reset() {
@@ -139,6 +202,7 @@ class ApplicationModel {
       val.superClassMap = null;
       val.anonymousSchemaToSubClassMap = null;
       val.modelClassMap = null;
+      val.nameToSchemaMap = null;
     });
   }
 }

--- a/lib/applicationModel.js
+++ b/lib/applicationModel.js
@@ -180,7 +180,6 @@ class ApplicationModel {
       const existingModelClass = this.modelClassMap[subclassName];
       if (existingModelClass) {
         existingModelClass.setSuperClassName(this.superClassMap[schemaName]);
-        modelClass = existingModelClass;
       }
       return subclassName;
     }

--- a/lib/modelClass.js
+++ b/lib/modelClass.js
@@ -1,7 +1,6 @@
 const _ = require('lodash');
 
 class ModelClass {
-
   constructor() {
     this.innerClass = true;
   }

--- a/lib/modelClass.js
+++ b/lib/modelClass.js
@@ -1,6 +1,11 @@
 const _ = require('lodash');
 
 class ModelClass {
+
+  constructor() {
+    this.innerClass = true;
+  }
+
   getClassName() {
     return this.className;
   }
@@ -31,6 +36,14 @@ class ModelClass {
 
   fixClassName(originalName) {
     return _.upperFirst(_.camelCase(originalName));
+  }
+
+  setCanBeInnerClass(innerClass) {
+    this.innerClass = innerClass;
+  }
+
+  canBeInnerClass() {
+    return this.innerClass;
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,13 +40,13 @@
       "dev": true
     },
     "@asyncapi/generator": {
-      "version": "1.8.18",
-      "resolved": "https://registry.npmjs.org/@asyncapi/generator/-/generator-1.8.18.tgz",
-      "integrity": "sha512-Z+4gxUr7eRqim8/jjpo3Kq+aNO71YC604idkrFyMXLOlNCl0rzmIHoWZCnC/PuKaP1rKXNLiZwnKCDVeNd90eg==",
+      "version": "1.8.19",
+      "resolved": "https://registry.npmjs.org/@asyncapi/generator/-/generator-1.8.19.tgz",
+      "integrity": "sha512-kQyZOo39tZL+OUnw//LZqafsPf5wwV9X3YFFWDR5IDdKXErKksacCWwZb88tU2JjvW3O3PDbyV+01FQ+Ye5+0w==",
       "dev": true,
       "requires": {
         "@asyncapi/avro-schema-parser": "^0.6.0",
-        "@asyncapi/generator-react-sdk": "^0.2.18",
+        "@asyncapi/generator-react-sdk": "^0.2.19",
         "@asyncapi/openapi-schema-parser": "^2.0.1",
         "@asyncapi/parser": "^1.10.2",
         "@asyncapi/raml-dt-schema-parser": "^2.0.1",
@@ -5231,13 +5231,13 @@
       "dev": true
     },
     "browserslist": {
-      "version": "4.17.5",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.5.tgz",
-      "integrity": "sha512-I3ekeB92mmpctWBoLXe0d5wPS2cBuRvvW0JyyJHMrk9/HmP2ZjrTboNAZ8iuGqaEIlKguljbQY32OkOJIRrgoA==",
+      "version": "4.17.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.6.tgz",
+      "integrity": "sha512-uPgz3vyRTlEiCv4ee9KlsKgo2V6qPk7Jsn0KAn2OBqbqKo3iNcPEC1Ti6J4dwnz+aIRfEEEuOzC9IBk8tXUomw==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001271",
-        "electron-to-chromium": "^1.3.878",
+        "caniuse-lite": "^1.0.30001274",
+        "electron-to-chromium": "^1.3.886",
         "escalade": "^3.1.1",
         "node-releases": "^2.0.1",
         "picocolors": "^1.0.0"
@@ -5355,9 +5355,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001274",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001274.tgz",
-      "integrity": "sha512-+Nkvv0fHyhISkiMIjnyjmf5YJcQ1IQHZN6U9TLUMroWR38FNwpsC51Gb68yueafX1V6ifOisInSgP9WJFS13ew==",
+      "version": "1.0.30001275",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001275.tgz",
+      "integrity": "sha512-ihJVvj8RX0kn9GgP43HKhb5q9s2XQn4nEQhdldEJvZhCsuiB2XOq6fAMYQZaN6FPWfsr2qU0cdL0CSbETwbJAg==",
       "dev": true
     },
     "cardinal": {
@@ -5689,12 +5689,12 @@
       }
     },
     "core-js-compat": {
-      "version": "3.19.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.19.0.tgz",
-      "integrity": "sha512-R09rKZ56ccGBebjTLZHvzDxhz93YPT37gBm6qUhnwj3Kt7aCjjZWD1injyNbyeFHxNKfeZBSyds6O9n3MKq1sw==",
+      "version": "3.19.1",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.19.1.tgz",
+      "integrity": "sha512-Q/VJ7jAF/y68+aUsQJ/afPOewdsGkDtcMb40J8MbuWKlK3Y+wtHq8bTHKPj2WKWLIqmS5JhHs4CzHtz6pT2W6g==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.17.5",
+        "browserslist": "^4.17.6",
         "semver": "7.0.0"
       },
       "dependencies": {
@@ -6057,9 +6057,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.886",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.886.tgz",
-      "integrity": "sha512-+vYdeBosI63VkCtNWnEVFjgNd/IZwvnsWkKyPtWAvrhA+XfByKoBJcbsMgudVU/bUcGAF9Xp3aXn96voWlc3oQ==",
+      "version": "1.3.887",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.887.tgz",
+      "integrity": "sha512-QQUumrEjFDKSVYVdaeBmFdyQGoaV+fCSMyWHvfx/u22bRHSTeBQYt6P4jMY+gFd4kgKB9nqk7RMtWkDB49OYPA==",
       "dev": true
     },
     "emittery": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@types/node": "^16.7.1"
   },
   "devDependencies": {
-    "@asyncapi/generator": "^1.8.18",
+    "@asyncapi/generator": "^1.8.19",
     "@semantic-release/commit-analyzer": "^8.0.1",
     "@semantic-release/github": "^7.0.4",
     "@semantic-release/npm": "^7.1.3",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test": "jest --maxWorkers=50% --detectOpenHandles",
     "test:watch": "npm run test -- --watch",
     "test:watchAll": "npm run test -- --watchAll",
-    "test:coverage": "npm run test -- --coverage"
+    "test:coverage": "npm run test -- --coverage",
+    "test:updateSnapshots": "npm run test -- -u"
   },
   "keywords": [
     "asyncapi",

--- a/partials/all-args-constructor
+++ b/partials/all-args-constructor
@@ -1,0 +1,30 @@
+{%- macro allArgsConstructor(className, properties, indentLevel) -%}
+{% set indent1 = indentLevel | indent1 -%}
+{% set indent2 = indentLevel | indent2 -%}
+{% set indent3 = indentLevel | indent3 -%}
+{% set first = true -%}
+{%- set hasNoProperties = properties | isEmpty -%}
+{%- if not hasNoProperties -%}
+{{ indent2 }}public {{ className }} (
+{%- for name, prop in properties -%}
+{%- set propModelClass = {schema: prop, schemaName: name} | getModelClass %}
+{%- set realClassName = propModelClass.getClassName() %}
+{%- set variableName = realClassName | identifierName %}
+{%- set typeInfo = [name, realClassName, prop] | fixType %}
+{%- set type = typeInfo[0] -%}
+{%- if first -%}
+{%- set first = false -%}
+{%- else -%}
+, {% endif %}
+{{ indent3 }}{{ type }} {{ variableName }}
+{%- endfor -%}
+) {
+{% for name, prop in properties -%}
+{%- set propModelClass = {schema: prop, schemaName: name} | getModelClass %}
+{%- set realClassName = propModelClass.getClassName() %}
+{%- set variableName = realClassName | identifierName -%}
+{{ indent3 }}this.{{ variableName }} = {{ variableName }};
+{% endfor -%}
+{{ indent2 }}}
+{%- endif -%}
+{% endmacro %}

--- a/partials/java-class
+++ b/partials/java-class
@@ -1,5 +1,6 @@
-{%- macro javaClass(schemaName, schema, properties, indentLevel, isStatic) %}
-{%- set modelClass = schemaName | getModelClass %}
+{%- macro javaClass(schemaName, schema, properties, indentLevel, isStatic, isInnerClass) %}
+{%- set modelClass = {schema: schema, schemaName: schemaName} | getModelClass %}
+{%- if modelClass %}
 {%- set className = modelClass.getClassName() %}
 {{ 'javaClass' | logJavaClass -}}
 {{ className | logJavaClass -}}
@@ -14,7 +15,7 @@
 {{ indent2 }}}
 
 {# If the top level object is an array, we need to deal with that specially. -#}
-{%- if schema and schema.type() === 'array' -%}
+{%- if schema and schema.type() === 'array' and not isInnerClass -%}
 {%- set name = schema.title() | camelCase -%}
 {%- set type = name | upperFirst -%}
 {%- set arrayType = type + '[]' -%}
@@ -26,7 +27,7 @@
 {{ indent2 }}public {{ arrayType }} get{{ type }}() { return {{ name }}; }
 {{ indent2 }}public void set{{ type }}({{ arrayType }} {{ name }}) { this.{{ name }} = {{name}}; }
 
-{{ javaClass(type, null, schema.items().properties(), indentLevel+1, true) }}
+{{ javaClass(type, null, schema.items().properties(), indentLevel+1, true, false) }}
 {%- else -%} {# not an array at the top level. #}
 {%- set first = true -%}
 {#- Constructor with all properties -#}
@@ -78,15 +79,15 @@
 {{ indent3 }}return this;
 {{ indent2 }}}
 {# Inner classes #}
-{%- if prop.type() === 'object' %}
-{{ javaClass(javaName, null, prop.properties(), indentLevel+1, true) }}
+{%- set innerModelClass = {schema: prop, schemaName: javaName} | getModelClass %}
+{%- if prop.type() === 'object' and innerModelClass %}
+{{ javaClass(javaName, prop, prop.properties(), indentLevel+1, true, true) }}
 {% endif -%}
-{%- if isArrayOfObjects %}
-{{ javaClass(javaName, null, prop.items().properties(), indentLevel+1, true) }}
+{%- if isArrayOfObjects and innerModelClass %}
+{{ javaClass(javaName, prop, prop.items().properties(), indentLevel+1, true, true) }}
 {% endif -%}
 {# Enums #}
 {%- if prop.enum() %}
-
 {{ indent2 }}public static enum {{ type }} { {{ prop.enum() }} }
 {% endif -%}
 {%- endfor %}
@@ -101,5 +102,5 @@
 {{ indent3 }}+ " super: " + super.toString(){% endif %}
 {{ indent3 }}+ " ]";
 {{ indent2 }}}
-{{ indent1 }}}
+{{ indent1 }}}{% endif %}
 {% endmacro -%}

--- a/partials/java-class
+++ b/partials/java-class
@@ -3,8 +3,8 @@
 {%- set modelClass = {schema: schema, schemaName: schemaName} | getModelClass %}
 {%- set schemaForRef = schemaName | getAnonymousSchemaForRef %}
 {% if schemaForRef %}
-	{% set schema = schemaForRef %}
-	{% set properties = schemaForRef.properties() %}
+{% set schema = schemaForRef %}
+{% set properties = schemaForRef.properties() %}
 {% endif %}
 {%- if modelClass %}
 {%- set className = modelClass.getClassName() %}
@@ -41,7 +41,6 @@
 
 {#- Getters and Setters #}
 {%- for name, prop in properties %}
-{#- TODO: This writes in the object names based on property name but the property name isn't always right because it might just be a ref - translate that into a real class name by ... getting the model class? yeah we can do that. pass in a null schema. -#}
 {%- set propModelClass = {schema: prop, schemaName: name} | getModelClass %}
 {%- set realClassName = propModelClass.getClassName() %}
 {%- set variableName = realClassName | identifierName -%}

--- a/partials/java-class
+++ b/partials/java-class
@@ -1,5 +1,10 @@
-{%- macro javaClass(schemaName, schema, properties, indentLevel, isStatic, isInnerClass) %}
+{%- macro javaClass(schemaName, schema, properties, indentLevel, isStatic) %}
 {%- set modelClass = {schema: schema, schemaName: schemaName} | getModelClass %}
+{%- set schemaForRef = schemaName | getAnonymousSchemaForRef %}
+{% if schemaForRef %}
+	{% set schema = schemaForRef %}
+	{% set properties = schemaForRef.properties() %}
+{% endif %}
 {%- if modelClass %}
 {%- set className = modelClass.getClassName() %}
 {{ 'javaClass' | logJavaClass -}}
@@ -15,19 +20,8 @@
 {{ indent2 }}}
 
 {# If the top level object is an array, we need to deal with that specially. -#}
-{%- if schema and schema.type() === 'array' and not isInnerClass -%}
-{%- set name = schema.title() | camelCase -%}
-{%- set type = name | upperFirst -%}
-{%- set arrayType = type + '[]' -%}
-{{ indent2 }}public {{ className }} ({{ arrayType }} {{ name }}) {
-{{ indent3 }}this.{{ name }} = {{ name }};
-{{ indent2 }}}
-{{ indent2 }}private {{ arrayType }} {{ name }};
-
-{{ indent2 }}public {{ arrayType }} get{{ type }}() { return {{ name }}; }
-{{ indent2 }}public void set{{ type }}({{ arrayType }} {{ name }}) { this.{{ name }} = {{name}}; }
-
-{{ javaClass(type, null, schema.items().properties(), indentLevel+1, true, false) }}
+{%- if schema and schema.type() === 'array' -%}
+{{ javaClass(type, null, schema.items().properties(), indentLevel+1, true) }}
 {%- else -%} {# not an array at the top level. #}
 {%- set first = true -%}
 {#- Constructor with all properties -#}
@@ -35,72 +29,83 @@
 {%- if not hasNoProperties -%}
 {{ indent2 }}public {{ className }} (
 {%- for name, prop in properties -%}
-{%- set javaName = name | identifierName -%}
-{%- set typeInfo = [name, javaName, prop] | fixType -%}
+{%- set propModelClass = {schema: prop, schemaName: name} | getModelClass %}
+{%- set realClassName = propModelClass.getClassName() %}
+{%- set variableName = realClassName | identifierName %}
+{%- set typeInfo = [name, realClassName, prop] | fixType %}
 {%- set type = typeInfo[0] -%}
 {%- if first -%}
 {%- set first = false -%}
 {%- else -%}
 , {% endif %}
-{{ indent3 }}{{ type }} {{ javaName }}
+{{ indent3 }}{{ type }} {{ variableName }}
 {%- endfor -%}
 ) {
 {% for name, prop in properties -%}
-{%- set javaName = name | identifierName -%}
-{{ indent3 }}this.{{ javaName }} = {{ javaName }};
+{%- set propModelClass = {schema: prop, schemaName: name} | getModelClass %}
+{%- set realClassName = propModelClass.getClassName() %}
+{%- set variableName = realClassName | identifierName -%}
+{{ indent3 }}this.{{ variableName }} = {{ variableName }};
 {% endfor -%}
 {{ indent2 }}}
 {% endif -%}
 {% endif -%}
 
 {# Members #}
-{% for name, prop in properties -%}
-{% set javaName = name | identifierName -%}
-{% set typeInfo = [javaName, javaName, prop] | fixType -%}
-{% set type = typeInfo[0] %}
-{% if javaName !== name -%}
+{%- for name, prop in properties %}
+{%- set propModelClass = {schema: prop, schemaName: name} | getModelClass %}
+{%- set realClassName = propModelClass.getClassName() %}
+{%- set variableName = realClassName | identifierName -%}
+{%- set typeInfo = [realClassName, realClassName, prop] | fixType -%}
+{%- set type = typeInfo[0] %}
+{% if variableName !== name -%}
 {{ indent2 }}@JsonProperty("{{name}}")
 {% endif -%}
-{{ indent2 }}private {{ type }} {{ javaName }};
-{%- endfor -%}
+{{ indent2 }}private {{ type }} {{ variableName }};
+{%- endfor %}
 
-{# Getters and Setters #}
+{#- Getters and Setters #}
 {%- for name, prop in properties %}
-{% set javaName = name | identifierName -%}
-{% set typeInfo = [name, javaName, prop] | fixType -%}
+{#- TODO: This writes in the object names based on property name but the property name isn't always right because it might just be a ref - translate that into a real class name by ... getting the model class? yeah we can do that. pass in a null schema. -#}
+{%- set propModelClass = {schema: prop, schemaName: name} | getModelClass %}
+{%- set realClassName = propModelClass.getClassName() %}
+{%- set variableName = realClassName | identifierName -%}
+{%- set typeInfo = [name, realClassName, prop] | fixType -%}
 {% set type = typeInfo[0] -%}
 {% set isArrayOfObjects = typeInfo[1] %}
-{{ indent2 }}public {{ type }} get{{- javaName | upperFirst }}() {
-{{ indent3 }}return {{ javaName }};
+{{ indent2 }}public {{ type }} get{{- realClassName }}() {
+{{ indent3 }}return {{ variableName }};
 {{ indent2 }}}
 
-{{ indent2 }}public {{ className }} set{{- javaName | upperFirst }}({{ type }} {{ javaName }}) {
-{{ indent3 }}this.{{-javaName }} = {{ javaName }};
+{{ indent2 }}public {{ className }} set{{- realClassName }}({{ type }} {{ variableName }}) {
+{{ indent3 }}this.{{-variableName }} = {{ variableName }};
 {{ indent3 }}return this;
 {{ indent2 }}}
 {# Inner classes #}
-{%- set innerModelClass = {schema: prop, schemaName: javaName} | getModelClass %}
-{%- if prop.type() === 'object' and innerModelClass %}
-{{ javaClass(javaName, prop, prop.properties(), indentLevel+1, true, true) }}
-{% endif -%}
-{%- if isArrayOfObjects and innerModelClass %}
-{{ javaClass(javaName, prop, prop.items().properties(), indentLevel+1, true, true) }}
-{% endif -%}
+{%- set innerModelClass = {schema: prop, schemaName: variableName} | getModelClass %}
+{%- if prop.type() === 'object' and innerModelClass and innerModelClass.canBeInnerClass() %}
+{{ javaClass(variableName, prop, prop.properties(), indentLevel+1, true) }}
+{%- endif %}
+{%- if isArrayOfObjects and innerModelClass and innerModelClass.canBeInnerClass() %}
+{{ javaClass(variableName, prop, prop.items().properties(), indentLevel+1, true) }}
+{%- endif %}
 {# Enums #}
 {%- if prop.enum() %}
 {{ indent2 }}public static enum {{ type }} { {{ prop.enum() }} }
-{% endif -%}
-{%- endfor %}
+{%- endif %}
+{%- endfor -%}
 
 {{ indent2 }}public String toString() {
 {{ indent3 }}return "{{ className }} ["
 {%- for name, prop in properties %}
-{%- set javaName = name | identifierName %}
-{{ indent3 }}+ " {{ javaName }}: " + {{ javaName }}
+{%- set propModelClass = {schema: prop, schemaName: name} | getModelClass %}
+{%- set realClassName = propModelClass.getClassName() %}
+{%- set variableName = realClassName | identifierName %}
+{{ indent3 }}+ " {{ variableName }}: " + {{ variableName }}
 {%- endfor %}
 {%- if modelClass.isSubClass() %}
 {{ indent3 }}+ " super: " + super.toString(){% endif %}
 {{ indent3 }}+ " ]";
 {{ indent2 }}}
-{{ indent1 }}}{% endif %}
-{% endmacro -%}
+{{ indent1 }}}{% endif -%}
+{%- endmacro -%}

--- a/partials/java-class
+++ b/partials/java-class
@@ -1,3 +1,4 @@
+{% from "partials/all-args-constructor" import allArgsConstructor -%}
 {%- macro javaClass(schemaName, schema, properties, indentLevel, isStatic) %}
 {%- set modelClass = {schema: schema, schemaName: schemaName} | getModelClass %}
 {%- set schemaForRef = schemaName | getAnonymousSchemaForRef %}
@@ -18,39 +19,13 @@
 {# Default constructor #}
 {{ indent2 }}public {{ className }} () {
 {{ indent2 }}}
-
 {# If the top level object is an array, we need to deal with that specially. -#}
 {%- if schema and schema.type() === 'array' -%}
+{{ allArgsConstructor(className, schema.items().properties(), indentLevel) }}
 {{ javaClass(type, null, schema.items().properties(), indentLevel+1, true) }}
 {%- else -%} {# not an array at the top level. #}
-{%- set first = true -%}
-{#- Constructor with all properties -#}
-{%- set hasNoProperties = properties | isEmpty -%}
-{%- if not hasNoProperties -%}
-{{ indent2 }}public {{ className }} (
-{%- for name, prop in properties -%}
-{%- set propModelClass = {schema: prop, schemaName: name} | getModelClass %}
-{%- set realClassName = propModelClass.getClassName() %}
-{%- set variableName = realClassName | identifierName %}
-{%- set typeInfo = [name, realClassName, prop] | fixType %}
-{%- set type = typeInfo[0] -%}
-{%- if first -%}
-{%- set first = false -%}
-{%- else -%}
-, {% endif %}
-{{ indent3 }}{{ type }} {{ variableName }}
-{%- endfor -%}
-) {
-{% for name, prop in properties -%}
-{%- set propModelClass = {schema: prop, schemaName: name} | getModelClass %}
-{%- set realClassName = propModelClass.getClassName() %}
-{%- set variableName = realClassName | identifierName -%}
-{{ indent3 }}this.{{ variableName }} = {{ variableName }};
-{% endfor -%}
-{{ indent2 }}}
+{{ allArgsConstructor(className, properties, indentLevel) }}
 {% endif -%}
-{% endif -%}
-
 {# Members #}
 {%- for name, prop in properties %}
 {%- set propModelClass = {schema: prop, schemaName: name} | getModelClass %}

--- a/test/__snapshots__/integration.test.js.snap
+++ b/test/__snapshots__/integration.test.js.snap
@@ -430,6 +430,538 @@ logging:
 "
 `;
 
+exports[`template integration tests using the generator should generate code from the smarty lighting streetlights example 1`] = `
+"
+import java.util.function.Consumer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.stream.function.StreamBridge;
+import org.springframework.context.annotation.Bean;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+
+@SpringBootApplication
+public class Application {
+
+	private static final Logger logger = LoggerFactory.getLogger(Application.class);
+
+	@Autowired
+	private StreamBridge streamBridge;
+
+	public static void main(String[] args) {
+		SpringApplication.run(Application.class);
+	}
+
+	@Bean
+	public Consumer<LightMeasuredPayload> receiveLightMeasurement() {
+		return data -> {
+			// Add business logic here.	
+			logger.info(data.toString());
+		};
+	}
+
+
+
+
+	public void sendTurnOn(
+		TurnOnOffPayload payload, String streetlightId
+		) {
+		String topic = String.format(\\"smartylighting/streetlights/1/0/action/%s/turn/on\\",
+			streetlightId);
+		streamBridge.send(topic, payload);
+	}
+	public void sendTurnOff(
+		TurnOnOffPayload payload, String streetlightId
+		) {
+		String topic = String.format(\\"smartylighting/streetlights/1/0/action/%s/turn/off\\",
+			streetlightId);
+		streamBridge.send(topic, payload);
+	}
+	public void sendDimLight(
+		DimLightPayload payload, String streetlightId
+		) {
+		String topic = String.format(\\"smartylighting/streetlights/1/0/action/%s/dim\\",
+			streetlightId);
+		streamBridge.send(topic, payload);
+	}
+}
+"
+`;
+
+exports[`template integration tests using the generator should generate code from the smarty lighting streetlights example 2`] = `
+"
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class DimLightPayload {
+
+	public DimLightPayload () {
+	}
+
+	public DimLightPayload (
+		Integer percentage, 
+		SentAt sentAt) {
+		this.percentage = percentage;
+		this.sentAt = sentAt;
+	}
+
+
+	private Integer percentage;
+	private SentAt sentAt;
+
+	public Integer getPercentage() {
+		return percentage;
+	}
+
+	public DimLightPayload setPercentage(Integer percentage) {
+		this.percentage = percentage;
+		return this;
+	}
+
+
+	public SentAt getSentAt() {
+		return sentAt;
+	}
+
+	public DimLightPayload setSentAt(SentAt sentAt) {
+		this.sentAt = sentAt;
+		return this;
+	}
+
+
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	public static class SentAt {
+
+		public SentAt () {
+		}
+
+		public SentAt (
+			PropertySubobject propertySubobject) {
+			this.propertySubobject = propertySubobject;
+		}
+
+
+		private PropertySubobject propertySubobject;
+
+		public PropertySubobject getPropertySubobject() {
+			return propertySubobject;
+		}
+
+		public SentAt setPropertySubobject(PropertySubobject propertySubobject) {
+			this.propertySubobject = propertySubobject;
+			return this;
+		}
+
+
+		@JsonInclude(JsonInclude.Include.NON_NULL)
+		public static class SubObject {
+
+			public SubObject () {
+			}
+
+			public SubObject (
+				String propertyA) {
+				this.propertyA = propertyA;
+			}
+
+
+			private String propertyA;
+
+			public String getPropertyA() {
+				return propertyA;
+			}
+
+			public SubObject setPropertyA(String propertyA) {
+				this.propertyA = propertyA;
+				return this;
+			}
+
+
+			public String toString() {
+				return \\"SubObject [\\"
+				+ \\" propertyA: \\" + propertyA
+				+ \\" ]\\";
+			}
+		}
+
+
+
+		public String toString() {
+			return \\"SentAt [\\"
+			+ \\" propertySubobject: \\" + propertySubobject
+			+ \\" ]\\";
+		}
+	}
+
+
+
+	public String toString() {
+		return \\"DimLightPayload [\\"
+		+ \\" percentage: \\" + percentage
+		+ \\" sentAt: \\" + sentAt
+		+ \\" ]\\";
+	}
+}
+
+"
+`;
+
+exports[`template integration tests using the generator should generate code from the smarty lighting streetlights example 3`] = `
+"
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class LightMeasuredPayload {
+
+	public LightMeasuredPayload () {
+	}
+
+	public LightMeasuredPayload (
+		Integer lumens, 
+		SentAt sentAt) {
+		this.lumens = lumens;
+		this.sentAt = sentAt;
+	}
+
+
+	private Integer lumens;
+	private SentAt sentAt;
+
+	public Integer getLumens() {
+		return lumens;
+	}
+
+	public LightMeasuredPayload setLumens(Integer lumens) {
+		this.lumens = lumens;
+		return this;
+	}
+
+
+	public SentAt getSentAt() {
+		return sentAt;
+	}
+
+	public LightMeasuredPayload setSentAt(SentAt sentAt) {
+		this.sentAt = sentAt;
+		return this;
+	}
+
+
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	public static class SentAt {
+
+		public SentAt () {
+		}
+
+		public SentAt (
+			PropertySubobject propertySubobject) {
+			this.propertySubobject = propertySubobject;
+		}
+
+
+		private PropertySubobject propertySubobject;
+
+		public PropertySubobject getPropertySubobject() {
+			return propertySubobject;
+		}
+
+		public SentAt setPropertySubobject(PropertySubobject propertySubobject) {
+			this.propertySubobject = propertySubobject;
+			return this;
+		}
+
+
+		@JsonInclude(JsonInclude.Include.NON_NULL)
+		public static class SubObject {
+
+			public SubObject () {
+			}
+
+			public SubObject (
+				String propertyA) {
+				this.propertyA = propertyA;
+			}
+
+
+			private String propertyA;
+
+			public String getPropertyA() {
+				return propertyA;
+			}
+
+			public SubObject setPropertyA(String propertyA) {
+				this.propertyA = propertyA;
+				return this;
+			}
+
+
+			public String toString() {
+				return \\"SubObject [\\"
+				+ \\" propertyA: \\" + propertyA
+				+ \\" ]\\";
+			}
+		}
+
+
+
+		public String toString() {
+			return \\"SentAt [\\"
+			+ \\" propertySubobject: \\" + propertySubobject
+			+ \\" ]\\";
+		}
+	}
+
+
+
+	public String toString() {
+		return \\"LightMeasuredPayload [\\"
+		+ \\" lumens: \\" + lumens
+		+ \\" sentAt: \\" + sentAt
+		+ \\" ]\\";
+	}
+}
+
+"
+`;
+
+exports[`template integration tests using the generator should generate code from the smarty lighting streetlights example 4`] = `
+"
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class SentAt {
+
+	public SentAt () {
+	}
+
+	public SentAt (
+		PropertySubobject propertySubobject) {
+		this.propertySubobject = propertySubobject;
+	}
+
+
+	private PropertySubobject propertySubobject;
+
+	public PropertySubobject getPropertySubobject() {
+		return propertySubobject;
+	}
+
+	public SentAt setPropertySubobject(PropertySubobject propertySubobject) {
+		this.propertySubobject = propertySubobject;
+		return this;
+	}
+
+
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	public static class SubObject {
+
+		public SubObject () {
+		}
+
+		public SubObject (
+			String propertyA) {
+			this.propertyA = propertyA;
+		}
+
+
+		private String propertyA;
+
+		public String getPropertyA() {
+			return propertyA;
+		}
+
+		public SubObject setPropertyA(String propertyA) {
+			this.propertyA = propertyA;
+			return this;
+		}
+
+
+		public String toString() {
+			return \\"SubObject [\\"
+			+ \\" propertyA: \\" + propertyA
+			+ \\" ]\\";
+		}
+	}
+
+
+
+	public String toString() {
+		return \\"SentAt [\\"
+		+ \\" propertySubobject: \\" + propertySubobject
+		+ \\" ]\\";
+	}
+}
+
+"
+`;
+
+exports[`template integration tests using the generator should generate code from the smarty lighting streetlights example 5`] = `
+"
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class SubObject {
+
+	public SubObject () {
+	}
+
+	public SubObject (
+		String propertyA) {
+		this.propertyA = propertyA;
+	}
+
+
+	private String propertyA;
+
+	public String getPropertyA() {
+		return propertyA;
+	}
+
+	public SubObject setPropertyA(String propertyA) {
+		this.propertyA = propertyA;
+		return this;
+	}
+
+
+	public String toString() {
+		return \\"SubObject [\\"
+		+ \\" propertyA: \\" + propertyA
+		+ \\" ]\\";
+	}
+}
+
+"
+`;
+
+exports[`template integration tests using the generator should generate code from the smarty lighting streetlights example 6`] = `
+"
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class TurnOnOffPayload {
+
+	public TurnOnOffPayload () {
+	}
+
+	public TurnOnOffPayload (
+		Command command, 
+		SentAt sentAt) {
+		this.command = command;
+		this.sentAt = sentAt;
+	}
+
+
+	private Command command;
+	private SentAt sentAt;
+
+	public Command getCommand() {
+		return command;
+	}
+
+	public TurnOnOffPayload setCommand(Command command) {
+		this.command = command;
+		return this;
+	}
+
+	public static enum Command { on,off }
+
+
+	public SentAt getSentAt() {
+		return sentAt;
+	}
+
+	public TurnOnOffPayload setSentAt(SentAt sentAt) {
+		this.sentAt = sentAt;
+		return this;
+	}
+
+
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	public static class SentAt {
+
+		public SentAt () {
+		}
+
+		public SentAt (
+			PropertySubobject propertySubobject) {
+			this.propertySubobject = propertySubobject;
+		}
+
+
+		private PropertySubobject propertySubobject;
+
+		public PropertySubobject getPropertySubobject() {
+			return propertySubobject;
+		}
+
+		public SentAt setPropertySubobject(PropertySubobject propertySubobject) {
+			this.propertySubobject = propertySubobject;
+			return this;
+		}
+
+
+		@JsonInclude(JsonInclude.Include.NON_NULL)
+		public static class SubObject {
+
+			public SubObject () {
+			}
+
+			public SubObject (
+				String propertyA) {
+				this.propertyA = propertyA;
+			}
+
+
+			private String propertyA;
+
+			public String getPropertyA() {
+				return propertyA;
+			}
+
+			public SubObject setPropertyA(String propertyA) {
+				this.propertyA = propertyA;
+				return this;
+			}
+
+
+			public String toString() {
+				return \\"SubObject [\\"
+				+ \\" propertyA: \\" + propertyA
+				+ \\" ]\\";
+			}
+		}
+
+
+
+		public String toString() {
+			return \\"SentAt [\\"
+			+ \\" propertySubobject: \\" + propertySubobject
+			+ \\" ]\\";
+		}
+	}
+
+
+
+	public String toString() {
+		return \\"TurnOnOffPayload [\\"
+		+ \\" command: \\" + command
+		+ \\" sentAt: \\" + sentAt
+		+ \\" ]\\";
+	}
+}
+
+"
+`;
+
 exports[`template integration tests using the generator should generate extra config when using the paramatersToHeaders parameter 1`] = `
 "package com.acme;
 
@@ -508,6 +1040,617 @@ logging:
     root: info
     org:
       springframework: info
+
+"
+`;
+
+exports[`template integration tests using the generator should generate schemas with nested arrays 1`] = `
+"
+import java.util.function.Consumer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.stream.function.StreamBridge;
+import org.springframework.context.annotation.Bean;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+
+@SpringBootApplication
+public class Application {
+
+	private static final Logger logger = LoggerFactory.getLogger(Application.class);
+
+	@Autowired
+	private StreamBridge streamBridge;
+
+	public static void main(String[] args) {
+		SpringApplication.run(Application.class);
+	}
+
+	@Bean
+	public Consumer<Dossier> companyCustomerCompanyDebtorDebtorIdDossierDossierIdCreatedConsumer() {
+		return data -> {
+			// Add business logic here.	
+			logger.info(data.toString());
+		};
+	}
+
+	@Bean
+	public Consumer<Debtor> companyCustomerCompanyDebtorDebtorIdCreatedConsumer() {
+		return data -> {
+			// Add business logic here.	
+			logger.info(data.toString());
+		};
+	}
+
+
+
+	public void sendCompanyCustomerCompanyDebtorCreate(
+		Debtor payload, String customerCompany
+		) {
+		String topic = String.format(\\"Company/%s/debtor/create\\",
+			customerCompany);
+		streamBridge.send(topic, payload);
+	}
+	public void sendCompanyCustomerCompanyDebtorDebtorIdDossierCreate(
+		Dossier payload, String customerCompany, String debtorId
+		) {
+		String topic = String.format(\\"Company/%s/debtor/%s/Dossier/create\\",
+			customerCompany, debtorId);
+		streamBridge.send(topic, payload);
+	}
+}
+"
+`;
+
+exports[`template integration tests using the generator should generate schemas with nested arrays 2`] = `
+"
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class Dossier {
+
+	public Dossier () {
+	}
+
+	public Dossier (
+		java.math.BigDecimal premium, 
+		java.math.BigDecimal appliedDiscount, 
+		String productId, 
+		Options[] options, 
+		String id, 
+		String clientId) {
+		this.premium = premium;
+		this.appliedDiscount = appliedDiscount;
+		this.productId = productId;
+		this.options = options;
+		this.id = id;
+		this.clientId = clientId;
+	}
+
+
+	private java.math.BigDecimal premium;
+	@JsonProperty(\\"applied_discount\\")
+	private java.math.BigDecimal appliedDiscount;
+	@JsonProperty(\\"product_id\\")
+	private String productId;
+	private Options[] options;
+	private String id;
+	@JsonProperty(\\"client_id\\")
+	private String clientId;
+
+	public java.math.BigDecimal getPremium() {
+		return premium;
+	}
+
+	public Dossier setPremium(java.math.BigDecimal premium) {
+		this.premium = premium;
+		return this;
+	}
+
+
+	public java.math.BigDecimal getAppliedDiscount() {
+		return appliedDiscount;
+	}
+
+	public Dossier setAppliedDiscount(java.math.BigDecimal appliedDiscount) {
+		this.appliedDiscount = appliedDiscount;
+		return this;
+	}
+
+
+	public String getProductId() {
+		return productId;
+	}
+
+	public Dossier setProductId(String productId) {
+		this.productId = productId;
+		return this;
+	}
+
+
+	public Options[] getOptions() {
+		return options;
+	}
+
+	public Dossier setOptions(Options[] options) {
+		this.options = options;
+		return this;
+	}
+
+
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	public static class Options {
+
+		public Options () {
+		}
+
+		public Options (
+			String name, 
+			String id) {
+			this.name = name;
+			this.id = id;
+		}
+
+
+		private String name;
+		private String id;
+
+		public String getName() {
+			return name;
+		}
+
+		public Options setName(String name) {
+			this.name = name;
+			return this;
+		}
+
+
+		public String getId() {
+			return id;
+		}
+
+		public Options setId(String id) {
+			this.id = id;
+			return this;
+		}
+
+
+		public String toString() {
+			return \\"Options [\\"
+			+ \\" name: \\" + name
+			+ \\" id: \\" + id
+			+ \\" ]\\";
+		}
+	}
+
+
+
+	public String getId() {
+		return id;
+	}
+
+	public Dossier setId(String id) {
+		this.id = id;
+		return this;
+	}
+
+
+	public String getClientId() {
+		return clientId;
+	}
+
+	public Dossier setClientId(String clientId) {
+		this.clientId = clientId;
+		return this;
+	}
+
+
+	public String toString() {
+		return \\"Dossier [\\"
+		+ \\" premium: \\" + premium
+		+ \\" appliedDiscount: \\" + appliedDiscount
+		+ \\" productId: \\" + productId
+		+ \\" options: \\" + options
+		+ \\" id: \\" + id
+		+ \\" clientId: \\" + clientId
+		+ \\" ]\\";
+	}
+}
+
+"
+`;
+
+exports[`template integration tests using the generator should generate schemas with nested arrays 3`] = `
+"
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class Debtor {
+
+	public Debtor () {
+	}
+
+	public Debtor (
+		Emails[] emails, 
+		String birthdate, 
+		Address address, 
+		String lastName, 
+		Phones[] phones, 
+		String id, 
+		String firstName, 
+		BankAccount bankAccount) {
+		this.emails = emails;
+		this.birthdate = birthdate;
+		this.address = address;
+		this.lastName = lastName;
+		this.phones = phones;
+		this.id = id;
+		this.firstName = firstName;
+		this.bankAccount = bankAccount;
+	}
+
+
+	private Emails[] emails;
+	private String birthdate;
+	private Address address;
+	@JsonProperty(\\"last_name\\")
+	private String lastName;
+	private Phones[] phones;
+	private String id;
+	@JsonProperty(\\"first_name\\")
+	private String firstName;
+	@JsonProperty(\\"bank_account\\")
+	private BankAccount bankAccount;
+
+	public Emails[] getEmails() {
+		return emails;
+	}
+
+	public Debtor setEmails(Emails[] emails) {
+		this.emails = emails;
+		return this;
+	}
+
+
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	public static class Emails {
+
+		public Emails () {
+		}
+
+		public Emails (
+			String type, 
+			String email, 
+			Boolean preferred) {
+			this.type = type;
+			this.email = email;
+			this.preferred = preferred;
+		}
+
+
+		private String type;
+		private String email;
+		private Boolean preferred;
+
+		public String getType() {
+			return type;
+		}
+
+		public Emails setType(String type) {
+			this.type = type;
+			return this;
+		}
+
+
+		public String getEmail() {
+			return email;
+		}
+
+		public Emails setEmail(String email) {
+			this.email = email;
+			return this;
+		}
+
+
+		public Boolean getPreferred() {
+			return preferred;
+		}
+
+		public Emails setPreferred(Boolean preferred) {
+			this.preferred = preferred;
+			return this;
+		}
+
+
+		public String toString() {
+			return \\"Emails [\\"
+			+ \\" type: \\" + type
+			+ \\" email: \\" + email
+			+ \\" preferred: \\" + preferred
+			+ \\" ]\\";
+		}
+	}
+
+
+
+	public String getBirthdate() {
+		return birthdate;
+	}
+
+	public Debtor setBirthdate(String birthdate) {
+		this.birthdate = birthdate;
+		return this;
+	}
+
+
+	public Address getAddress() {
+		return address;
+	}
+
+	public Debtor setAddress(Address address) {
+		this.address = address;
+		return this;
+	}
+
+
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	public static class Address {
+
+		public Address () {
+		}
+
+		public Address (
+			String countryCode, 
+			String city, 
+			String street, 
+			String postalCode) {
+			this.countryCode = countryCode;
+			this.city = city;
+			this.street = street;
+			this.postalCode = postalCode;
+		}
+
+
+		@JsonProperty(\\"country_code\\")
+		private String countryCode;
+		private String city;
+		private String street;
+		@JsonProperty(\\"postal_code\\")
+		private String postalCode;
+
+		public String getCountryCode() {
+			return countryCode;
+		}
+
+		public Address setCountryCode(String countryCode) {
+			this.countryCode = countryCode;
+			return this;
+		}
+
+
+		public String getCity() {
+			return city;
+		}
+
+		public Address setCity(String city) {
+			this.city = city;
+			return this;
+		}
+
+
+		public String getStreet() {
+			return street;
+		}
+
+		public Address setStreet(String street) {
+			this.street = street;
+			return this;
+		}
+
+
+		public String getPostalCode() {
+			return postalCode;
+		}
+
+		public Address setPostalCode(String postalCode) {
+			this.postalCode = postalCode;
+			return this;
+		}
+
+
+		public String toString() {
+			return \\"Address [\\"
+			+ \\" countryCode: \\" + countryCode
+			+ \\" city: \\" + city
+			+ \\" street: \\" + street
+			+ \\" postalCode: \\" + postalCode
+			+ \\" ]\\";
+		}
+	}
+
+
+
+	public String getLastName() {
+		return lastName;
+	}
+
+	public Debtor setLastName(String lastName) {
+		this.lastName = lastName;
+		return this;
+	}
+
+
+	public Phones[] getPhones() {
+		return phones;
+	}
+
+	public Debtor setPhones(Phones[] phones) {
+		this.phones = phones;
+		return this;
+	}
+
+
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	public static class Phones {
+
+		public Phones () {
+		}
+
+		public Phones (
+			String phone, 
+			String type, 
+			Boolean preferred) {
+			this.phone = phone;
+			this.type = type;
+			this.preferred = preferred;
+		}
+
+
+		private String phone;
+		private String type;
+		private Boolean preferred;
+
+		public String getPhone() {
+			return phone;
+		}
+
+		public Phones setPhone(String phone) {
+			this.phone = phone;
+			return this;
+		}
+
+
+		public String getType() {
+			return type;
+		}
+
+		public Phones setType(String type) {
+			this.type = type;
+			return this;
+		}
+
+
+		public Boolean getPreferred() {
+			return preferred;
+		}
+
+		public Phones setPreferred(Boolean preferred) {
+			this.preferred = preferred;
+			return this;
+		}
+
+
+		public String toString() {
+			return \\"Phones [\\"
+			+ \\" phone: \\" + phone
+			+ \\" type: \\" + type
+			+ \\" preferred: \\" + preferred
+			+ \\" ]\\";
+		}
+	}
+
+
+
+	public String getId() {
+		return id;
+	}
+
+	public Debtor setId(String id) {
+		this.id = id;
+		return this;
+	}
+
+
+	public String getFirstName() {
+		return firstName;
+	}
+
+	public Debtor setFirstName(String firstName) {
+		this.firstName = firstName;
+		return this;
+	}
+
+
+	public BankAccount getBankAccount() {
+		return bankAccount;
+	}
+
+	public Debtor setBankAccount(BankAccount bankAccount) {
+		this.bankAccount = bankAccount;
+		return this;
+	}
+
+
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	public static class BankAccount {
+
+		public BankAccount () {
+		}
+
+		public BankAccount (
+			String iban, 
+			String bic) {
+			this.iban = iban;
+			this.bic = bic;
+		}
+
+
+		@JsonProperty(\\"IBAN\\")
+		private String iban;
+		@JsonProperty(\\"BIC\\")
+		private String bic;
+
+		public String getIban() {
+			return iban;
+		}
+
+		public BankAccount setIban(String iban) {
+			this.iban = iban;
+			return this;
+		}
+
+
+		public String getBic() {
+			return bic;
+		}
+
+		public BankAccount setBic(String bic) {
+			this.bic = bic;
+			return this;
+		}
+
+
+		public String toString() {
+			return \\"BankAccount [\\"
+			+ \\" iban: \\" + iban
+			+ \\" bic: \\" + bic
+			+ \\" ]\\";
+		}
+	}
+
+
+
+	public String toString() {
+		return \\"Debtor [\\"
+		+ \\" emails: \\" + emails
+		+ \\" birthdate: \\" + birthdate
+		+ \\" address: \\" + address
+		+ \\" lastName: \\" + lastName
+		+ \\" phones: \\" + phones
+		+ \\" id: \\" + id
+		+ \\" firstName: \\" + firstName
+		+ \\" bankAccount: \\" + bankAccount
+		+ \\" ]\\";
+	}
+}
 
 "
 `;

--- a/test/__snapshots__/integration.test.js.snap
+++ b/test/__snapshots__/integration.test.js.snap
@@ -6,6 +6,7 @@ exports[`template integration tests using the generator avro schemas should appe
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 
+
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class User {
 
@@ -21,11 +22,9 @@ public class User {
 		this.age = age;
 	}
 
-
 	private String displayName;
 	private String email;
 	private Integer age;
-
 	public String getDisplayName() {
 		return displayName;
 	}
@@ -55,7 +54,6 @@ public class User {
 		return this;
 	}
 
-
 	public String toString() {
 		return \\"User [\\"
 		+ \\" displayName: \\" + displayName
@@ -64,7 +62,6 @@ public class User {
 		+ \\" ]\\";
 	}
 }
-
 "
 `;
 
@@ -74,6 +71,7 @@ exports[`template integration tests using the generator avro schemas should appe
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 
+
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class User {
 
@@ -89,11 +87,9 @@ public class User {
 		this.age = age;
 	}
 
-
 	private String displayName;
 	private String email;
 	private Integer age;
-
 	public String getDisplayName() {
 		return displayName;
 	}
@@ -123,7 +119,6 @@ public class User {
 		return this;
 	}
 
-
 	public String toString() {
 		return \\"User [\\"
 		+ \\" displayName: \\" + displayName
@@ -132,7 +127,6 @@ public class User {
 		+ \\" ]\\";
 	}
 }
-
 "
 `;
 
@@ -189,6 +183,10 @@ exports[`template integration tests using the generator should generate a model 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 
+
+	
+	
+
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ExtendedErrorModel extends ErrorModel {
 
@@ -200,9 +198,7 @@ public class ExtendedErrorModel extends ErrorModel {
 		this.rootCause = rootCause;
 	}
 
-
 	private String rootCause;
-
 	public String getRootCause() {
 		return rootCause;
 	}
@@ -212,7 +208,6 @@ public class ExtendedErrorModel extends ErrorModel {
 		return this;
 	}
 
-
 	public String toString() {
 		return \\"ExtendedErrorModel [\\"
 		+ \\" rootCause: \\" + rootCause
@@ -220,7 +215,6 @@ public class ExtendedErrorModel extends ErrorModel {
 		+ \\" ]\\";
 	}
 }
-
 "
 `;
 
@@ -351,6 +345,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 
+
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class MySchema {
 
@@ -364,11 +359,9 @@ public class MySchema {
 		this._long = _long;
 	}
 
-
 	private String prop1;
 	@JsonProperty(\\"long\\")
 	private String _long;
-
 	public String getProp1() {
 		return prop1;
 	}
@@ -379,15 +372,14 @@ public class MySchema {
 	}
 
 
-	public String get_long() {
+	public String getLong() {
 		return _long;
 	}
 
-	public MySchema set_long(String _long) {
+	public MySchema setLong(String _long) {
 		this._long = _long;
 		return this;
 	}
-
 
 	public String toString() {
 		return \\"MySchema [\\"
@@ -396,7 +388,6 @@ public class MySchema {
 		+ \\" ]\\";
 	}
 }
-
 "
 `;
 
@@ -497,6 +488,7 @@ exports[`template integration tests using the generator should generate code fro
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 
+
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class DimLightPayload {
 
@@ -510,10 +502,8 @@ public class DimLightPayload {
 		this.sentAt = sentAt;
 	}
 
-
 	private Integer percentage;
 	private SentAt sentAt;
-
 	public Integer getPercentage() {
 		return percentage;
 	}
@@ -533,73 +523,6 @@ public class DimLightPayload {
 		return this;
 	}
 
-
-	@JsonInclude(JsonInclude.Include.NON_NULL)
-	public static class SentAt {
-
-		public SentAt () {
-		}
-
-		public SentAt (
-			PropertySubobject propertySubobject) {
-			this.propertySubobject = propertySubobject;
-		}
-
-
-		private PropertySubobject propertySubobject;
-
-		public PropertySubobject getPropertySubobject() {
-			return propertySubobject;
-		}
-
-		public SentAt setPropertySubobject(PropertySubobject propertySubobject) {
-			this.propertySubobject = propertySubobject;
-			return this;
-		}
-
-
-		@JsonInclude(JsonInclude.Include.NON_NULL)
-		public static class SubObject {
-
-			public SubObject () {
-			}
-
-			public SubObject (
-				String propertyA) {
-				this.propertyA = propertyA;
-			}
-
-
-			private String propertyA;
-
-			public String getPropertyA() {
-				return propertyA;
-			}
-
-			public SubObject setPropertyA(String propertyA) {
-				this.propertyA = propertyA;
-				return this;
-			}
-
-
-			public String toString() {
-				return \\"SubObject [\\"
-				+ \\" propertyA: \\" + propertyA
-				+ \\" ]\\";
-			}
-		}
-
-
-
-		public String toString() {
-			return \\"SentAt [\\"
-			+ \\" propertySubobject: \\" + propertySubobject
-			+ \\" ]\\";
-		}
-	}
-
-
-
 	public String toString() {
 		return \\"DimLightPayload [\\"
 		+ \\" percentage: \\" + percentage
@@ -607,13 +530,13 @@ public class DimLightPayload {
 		+ \\" ]\\";
 	}
 }
-
 "
 `;
 
 exports[`template integration tests using the generator should generate code from the smarty lighting streetlights example 3`] = `
 "
 import com.fasterxml.jackson.annotation.JsonInclude;
+
 
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -629,10 +552,8 @@ public class LightMeasuredPayload {
 		this.sentAt = sentAt;
 	}
 
-
 	private Integer lumens;
 	private SentAt sentAt;
-
 	public Integer getLumens() {
 		return lumens;
 	}
@@ -652,73 +573,6 @@ public class LightMeasuredPayload {
 		return this;
 	}
 
-
-	@JsonInclude(JsonInclude.Include.NON_NULL)
-	public static class SentAt {
-
-		public SentAt () {
-		}
-
-		public SentAt (
-			PropertySubobject propertySubobject) {
-			this.propertySubobject = propertySubobject;
-		}
-
-
-		private PropertySubobject propertySubobject;
-
-		public PropertySubobject getPropertySubobject() {
-			return propertySubobject;
-		}
-
-		public SentAt setPropertySubobject(PropertySubobject propertySubobject) {
-			this.propertySubobject = propertySubobject;
-			return this;
-		}
-
-
-		@JsonInclude(JsonInclude.Include.NON_NULL)
-		public static class SubObject {
-
-			public SubObject () {
-			}
-
-			public SubObject (
-				String propertyA) {
-				this.propertyA = propertyA;
-			}
-
-
-			private String propertyA;
-
-			public String getPropertyA() {
-				return propertyA;
-			}
-
-			public SubObject setPropertyA(String propertyA) {
-				this.propertyA = propertyA;
-				return this;
-			}
-
-
-			public String toString() {
-				return \\"SubObject [\\"
-				+ \\" propertyA: \\" + propertyA
-				+ \\" ]\\";
-			}
-		}
-
-
-
-		public String toString() {
-			return \\"SentAt [\\"
-			+ \\" propertySubobject: \\" + propertySubobject
-			+ \\" ]\\";
-		}
-	}
-
-
-
 	public String toString() {
 		return \\"LightMeasuredPayload [\\"
 		+ \\" lumens: \\" + lumens
@@ -726,13 +580,13 @@ public class LightMeasuredPayload {
 		+ \\" ]\\";
 	}
 }
-
 "
 `;
 
 exports[`template integration tests using the generator should generate code from the smarty lighting streetlights example 4`] = `
 "
 import com.fasterxml.jackson.annotation.JsonInclude;
+
 
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -742,63 +596,27 @@ public class SentAt {
 	}
 
 	public SentAt (
-		PropertySubobject propertySubobject) {
-		this.propertySubobject = propertySubobject;
+		SubObject subObject) {
+		this.subObject = subObject;
 	}
 
-
-	private PropertySubobject propertySubobject;
-
-	public PropertySubobject getPropertySubobject() {
-		return propertySubobject;
+	@JsonProperty(\\"propertySubobject\\")
+	private SubObject subObject;
+	public SubObject getSubObject() {
+		return subObject;
 	}
 
-	public SentAt setPropertySubobject(PropertySubobject propertySubobject) {
-		this.propertySubobject = propertySubobject;
+	public SentAt setSubObject(SubObject subObject) {
+		this.subObject = subObject;
 		return this;
 	}
 
-
-	@JsonInclude(JsonInclude.Include.NON_NULL)
-	public static class SubObject {
-
-		public SubObject () {
-		}
-
-		public SubObject (
-			String propertyA) {
-			this.propertyA = propertyA;
-		}
-
-
-		private String propertyA;
-
-		public String getPropertyA() {
-			return propertyA;
-		}
-
-		public SubObject setPropertyA(String propertyA) {
-			this.propertyA = propertyA;
-			return this;
-		}
-
-
-		public String toString() {
-			return \\"SubObject [\\"
-			+ \\" propertyA: \\" + propertyA
-			+ \\" ]\\";
-		}
-	}
-
-
-
 	public String toString() {
 		return \\"SentAt [\\"
-		+ \\" propertySubobject: \\" + propertySubobject
+		+ \\" subObject: \\" + subObject
 		+ \\" ]\\";
 	}
 }
-
 "
 `;
 
@@ -806,44 +624,6 @@ exports[`template integration tests using the generator should generate code fro
 "
 import com.fasterxml.jackson.annotation.JsonInclude;
 
-
-@JsonInclude(JsonInclude.Include.NON_NULL)
-public class SubObject {
-
-	public SubObject () {
-	}
-
-	public SubObject (
-		String propertyA) {
-		this.propertyA = propertyA;
-	}
-
-
-	private String propertyA;
-
-	public String getPropertyA() {
-		return propertyA;
-	}
-
-	public SubObject setPropertyA(String propertyA) {
-		this.propertyA = propertyA;
-		return this;
-	}
-
-
-	public String toString() {
-		return \\"SubObject [\\"
-		+ \\" propertyA: \\" + propertyA
-		+ \\" ]\\";
-	}
-}
-
-"
-`;
-
-exports[`template integration tests using the generator should generate code from the smarty lighting streetlights example 6`] = `
-"
-import com.fasterxml.jackson.annotation.JsonInclude;
 
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -859,10 +639,8 @@ public class TurnOnOffPayload {
 		this.sentAt = sentAt;
 	}
 
-
 	private Command command;
 	private SentAt sentAt;
-
 	public Command getCommand() {
 		return command;
 	}
@@ -872,9 +650,8 @@ public class TurnOnOffPayload {
 		return this;
 	}
 
+
 	public static enum Command { on,off }
-
-
 	public SentAt getSentAt() {
 		return sentAt;
 	}
@@ -884,73 +661,6 @@ public class TurnOnOffPayload {
 		return this;
 	}
 
-
-	@JsonInclude(JsonInclude.Include.NON_NULL)
-	public static class SentAt {
-
-		public SentAt () {
-		}
-
-		public SentAt (
-			PropertySubobject propertySubobject) {
-			this.propertySubobject = propertySubobject;
-		}
-
-
-		private PropertySubobject propertySubobject;
-
-		public PropertySubobject getPropertySubobject() {
-			return propertySubobject;
-		}
-
-		public SentAt setPropertySubobject(PropertySubobject propertySubobject) {
-			this.propertySubobject = propertySubobject;
-			return this;
-		}
-
-
-		@JsonInclude(JsonInclude.Include.NON_NULL)
-		public static class SubObject {
-
-			public SubObject () {
-			}
-
-			public SubObject (
-				String propertyA) {
-				this.propertyA = propertyA;
-			}
-
-
-			private String propertyA;
-
-			public String getPropertyA() {
-				return propertyA;
-			}
-
-			public SubObject setPropertyA(String propertyA) {
-				this.propertyA = propertyA;
-				return this;
-			}
-
-
-			public String toString() {
-				return \\"SubObject [\\"
-				+ \\" propertyA: \\" + propertyA
-				+ \\" ]\\";
-			}
-		}
-
-
-
-		public String toString() {
-			return \\"SentAt [\\"
-			+ \\" propertySubobject: \\" + propertySubobject
-			+ \\" ]\\";
-		}
-	}
-
-
-
 	public String toString() {
 		return \\"TurnOnOffPayload [\\"
 		+ \\" command: \\" + command
@@ -958,7 +668,42 @@ public class TurnOnOffPayload {
 		+ \\" ]\\";
 	}
 }
+"
+`;
 
+exports[`template integration tests using the generator should generate code from the smarty lighting streetlights example 6`] = `
+"
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class SubObject {
+
+	public SubObject () {
+	}
+
+	public SubObject (
+		String propertyA) {
+		this.propertyA = propertyA;
+	}
+
+	private String propertyA;
+	public String getPropertyA() {
+		return propertyA;
+	}
+
+	public SubObject setPropertyA(String propertyA) {
+		this.propertyA = propertyA;
+		return this;
+	}
+
+	public String toString() {
+		return \\"SubObject [\\"
+		+ \\" propertyA: \\" + propertyA
+		+ \\" ]\\";
+	}
+}
 "
 `;
 
@@ -1112,6 +857,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 
+
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Dossier {
 
@@ -1133,7 +879,6 @@ public class Dossier {
 		this.clientId = clientId;
 	}
 
-
 	private java.math.BigDecimal premium;
 	@JsonProperty(\\"applied_discount\\")
 	private java.math.BigDecimal appliedDiscount;
@@ -1143,7 +888,6 @@ public class Dossier {
 	private String id;
 	@JsonProperty(\\"client_id\\")
 	private String clientId;
-
 	public java.math.BigDecimal getPremium() {
 		return premium;
 	}
@@ -1184,23 +928,17 @@ public class Dossier {
 	}
 
 
+
 	@JsonInclude(JsonInclude.Include.NON_NULL)
 	public static class Options {
 
 		public Options () {
 		}
 
-		public Options (
-			String name, 
-			String id) {
-			this.name = name;
-			this.id = id;
-		}
 
 
 		private String name;
 		private String id;
-
 		public String getName() {
 			return name;
 		}
@@ -1220,7 +958,6 @@ public class Dossier {
 			return this;
 		}
 
-
 		public String toString() {
 			return \\"Options [\\"
 			+ \\" name: \\" + name
@@ -1228,8 +965,6 @@ public class Dossier {
 			+ \\" ]\\";
 		}
 	}
-
-
 
 	public String getId() {
 		return id;
@@ -1250,7 +985,6 @@ public class Dossier {
 		return this;
 	}
 
-
 	public String toString() {
 		return \\"Dossier [\\"
 		+ \\" premium: \\" + premium
@@ -1262,7 +996,6 @@ public class Dossier {
 		+ \\" ]\\";
 	}
 }
-
 "
 `;
 
@@ -1270,6 +1003,7 @@ exports[`template integration tests using the generator should generate schemas 
 "
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -1297,7 +1031,6 @@ public class Debtor {
 		this.bankAccount = bankAccount;
 	}
 
-
 	private Emails[] emails;
 	private String birthdate;
 	private Address address;
@@ -1309,7 +1042,6 @@ public class Debtor {
 	private String firstName;
 	@JsonProperty(\\"bank_account\\")
 	private BankAccount bankAccount;
-
 	public Emails[] getEmails() {
 		return emails;
 	}
@@ -1320,26 +1052,18 @@ public class Debtor {
 	}
 
 
+
 	@JsonInclude(JsonInclude.Include.NON_NULL)
 	public static class Emails {
 
 		public Emails () {
 		}
 
-		public Emails (
-			String type, 
-			String email, 
-			Boolean preferred) {
-			this.type = type;
-			this.email = email;
-			this.preferred = preferred;
-		}
 
 
 		private String type;
 		private String email;
 		private Boolean preferred;
-
 		public String getType() {
 			return type;
 		}
@@ -1369,7 +1093,6 @@ public class Debtor {
 			return this;
 		}
 
-
 		public String toString() {
 			return \\"Emails [\\"
 			+ \\" type: \\" + type
@@ -1378,8 +1101,6 @@ public class Debtor {
 			+ \\" ]\\";
 		}
 	}
-
-
 
 	public String getBirthdate() {
 		return birthdate;
@@ -1401,6 +1122,7 @@ public class Debtor {
 	}
 
 
+
 	@JsonInclude(JsonInclude.Include.NON_NULL)
 	public static class Address {
 
@@ -1418,14 +1140,12 @@ public class Debtor {
 			this.postalCode = postalCode;
 		}
 
-
 		@JsonProperty(\\"country_code\\")
 		private String countryCode;
 		private String city;
 		private String street;
 		@JsonProperty(\\"postal_code\\")
 		private String postalCode;
-
 		public String getCountryCode() {
 			return countryCode;
 		}
@@ -1465,7 +1185,6 @@ public class Debtor {
 			return this;
 		}
 
-
 		public String toString() {
 			return \\"Address [\\"
 			+ \\" countryCode: \\" + countryCode
@@ -1475,8 +1194,6 @@ public class Debtor {
 			+ \\" ]\\";
 		}
 	}
-
-
 
 	public String getLastName() {
 		return lastName;
@@ -1498,26 +1215,18 @@ public class Debtor {
 	}
 
 
+
 	@JsonInclude(JsonInclude.Include.NON_NULL)
 	public static class Phones {
 
 		public Phones () {
 		}
 
-		public Phones (
-			String phone, 
-			String type, 
-			Boolean preferred) {
-			this.phone = phone;
-			this.type = type;
-			this.preferred = preferred;
-		}
 
 
 		private String phone;
 		private String type;
 		private Boolean preferred;
-
 		public String getPhone() {
 			return phone;
 		}
@@ -1547,7 +1256,6 @@ public class Debtor {
 			return this;
 		}
 
-
 		public String toString() {
 			return \\"Phones [\\"
 			+ \\" phone: \\" + phone
@@ -1556,8 +1264,6 @@ public class Debtor {
 			+ \\" ]\\";
 		}
 	}
-
-
 
 	public String getId() {
 		return id;
@@ -1589,6 +1295,7 @@ public class Debtor {
 	}
 
 
+
 	@JsonInclude(JsonInclude.Include.NON_NULL)
 	public static class BankAccount {
 
@@ -1602,12 +1309,10 @@ public class Debtor {
 			this.bic = bic;
 		}
 
-
 		@JsonProperty(\\"IBAN\\")
 		private String iban;
 		@JsonProperty(\\"BIC\\")
 		private String bic;
-
 		public String getIban() {
 			return iban;
 		}
@@ -1627,7 +1332,6 @@ public class Debtor {
 			return this;
 		}
 
-
 		public String toString() {
 			return \\"BankAccount [\\"
 			+ \\" iban: \\" + iban
@@ -1635,9 +1339,6 @@ public class Debtor {
 			+ \\" ]\\";
 		}
 	}
-
-
-
 	public String toString() {
 		return \\"Debtor [\\"
 		+ \\" emails: \\" + emails
@@ -1651,7 +1352,6 @@ public class Debtor {
 		+ \\" ]\\";
 	}
 }
-
 "
 `;
 

--- a/test/__snapshots__/integration.test.js.snap
+++ b/test/__snapshots__/integration.test.js.snap
@@ -184,8 +184,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 
 
 
-	
-	
+
+
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ExtendedErrorModel extends ErrorModel {

--- a/test/__snapshots__/integration.test.js.snap
+++ b/test/__snapshots__/integration.test.js.snap
@@ -934,7 +934,12 @@ public class Dossier {
 
 		public Options () {
 		}
-
+		public Options (
+			String name, 
+			String id) {
+			this.name = name;
+			this.id = id;
+		}
 
 
 		private String name;
@@ -1058,7 +1063,14 @@ public class Debtor {
 
 		public Emails () {
 		}
-
+		public Emails (
+			String type, 
+			String email, 
+			Boolean preferred) {
+			this.type = type;
+			this.email = email;
+			this.preferred = preferred;
+		}
 
 
 		private String type;
@@ -1221,7 +1233,14 @@ public class Debtor {
 
 		public Phones () {
 		}
-
+		public Phones (
+			String phone, 
+			String type, 
+			Boolean preferred) {
+			this.phone = phone;
+			this.type = type;
+			this.preferred = preferred;
+		}
 
 
 		private String phone;

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -6,12 +6,20 @@ const crypto = require('crypto');
 const MAIN_TEST_RESULT_PATH = path.join('test', 'temp', 'integrationTestResult');
 
 describe('template integration tests using the generator', () => {
+
+  jest.setTimeout(30000);
+
   const generateFolderName = () => {
     // you always want to generate to new directory to make sure test runs in clear environment
     return path.resolve(MAIN_TEST_RESULT_PATH, crypto.randomBytes(4).toString('hex'));
   };
 
-  jest.setTimeout(30000);
+  const assertExpectedFiles = async (outputDirectory, expectedFiles) => {
+    for (const index in expectedFiles) {
+      const file = await readFile(path.join(outputDirectory, expectedFiles[index]), 'utf8');
+      expect(file).toMatchSnapshot();
+    }
+  }
 
   it('should generate application files using the solace binder', async () => {
     const OUTPUT_DIR = generateFolderName();
@@ -37,10 +45,7 @@ describe('template integration tests using the generator', () => {
       `src/main/java/${PACKAGE_PATH}/MySchema.java`,
       'src/main/resources/application.yml'
     ];
-    for (const index in expectedFiles) {
-      const file = await readFile(path.join(OUTPUT_DIR, expectedFiles[index]), 'utf8');
-      expect(file).toMatchSnapshot();
-    }
+    await assertExpectedFiles(OUTPUT_DIR, expectedFiles);
   });
 
   it('should return payload when using x-scs-function-name instead of logging the message', async () => {
@@ -52,10 +57,7 @@ describe('template integration tests using the generator', () => {
     const expectedFiles = [
       'src/main/java/Application.java'
     ];
-    for (const index in expectedFiles) {
-      const file = await readFile(path.join(OUTPUT_DIR, expectedFiles[index]), 'utf8');
-      expect(file).toMatchSnapshot();
-    }
+    await assertExpectedFiles(OUTPUT_DIR, expectedFiles);
   });
 
   it('should generate extra config when using the paramatersToHeaders parameter', async () => {
@@ -80,10 +82,7 @@ describe('template integration tests using the generator', () => {
       `src/main/java/${PACKAGE_PATH}/Application.java`,
       'src/main/resources/application.yml'
     ];
-    for (const index in expectedFiles) {
-      const file = await readFile(path.join(OUTPUT_DIR, expectedFiles[index]), 'utf8');
-      expect(file).toMatchSnapshot();
-    }
+    await assertExpectedFiles(OUTPUT_DIR, expectedFiles);
   });
 
   it('should generate a comment for a consumer receiving multiple messages', async () => {
@@ -95,10 +94,7 @@ describe('template integration tests using the generator', () => {
     const expectedFiles = [
       'src/main/java/Application.java'
     ];
-    for (const index in expectedFiles) {
-      const file = await readFile(path.join(OUTPUT_DIR, expectedFiles[index]), 'utf8');
-      expect(file).toMatchSnapshot();
-    }
+    await assertExpectedFiles(OUTPUT_DIR, expectedFiles);
   });
 
   it('avro schemas should appear in a package based on their namespace, if any.', async () => {
@@ -120,10 +116,7 @@ describe('template integration tests using the generator', () => {
       `src/main/java/${PACKAGE_PATH}/User.java`,
       `src/main/java/${AVRO_PACKAGE_PATH}/User.java`,
     ];
-    for (const index in expectedFiles) {
-      const file = await readFile(path.join(OUTPUT_DIR, expectedFiles[index]), 'utf8');
-      expect(file).toMatchSnapshot();
-    }
+    await assertExpectedFiles(OUTPUT_DIR, expectedFiles);
   });
 
   it('should generate a model subclass when it sees an allOf', async () => {
@@ -141,9 +134,37 @@ describe('template integration tests using the generator', () => {
     const expectedFiles = [
       `src/main/java/${PACKAGE_PATH}/ExtendedErrorModel.java`
     ];
-    for (const index in expectedFiles) {
-      const file = await readFile(path.join(OUTPUT_DIR, expectedFiles[index]), 'utf8');
-      expect(file).toMatchSnapshot();
-    }
+    await assertExpectedFiles(OUTPUT_DIR, expectedFiles);
+  });
+
+  it('should generate schemas with nested arrays', async () => {
+    const OUTPUT_DIR = generateFolderName();
+    
+    const generator = new Generator(path.normalize('./'), OUTPUT_DIR, { forceWrite: true });
+    await generator.generateFromFile(path.resolve('test', 'mocks/nested-arrays.yaml'));
+
+    const expectedFiles = [
+      'src/main/java/Application.java',
+      'src/main/java/Dossier.java',
+      'src/main/java/Debtor.java'
+    ];
+    await assertExpectedFiles(OUTPUT_DIR, expectedFiles);
+  });
+
+  it('should generate code from the smarty lighting streetlights example', async () => {
+    const OUTPUT_DIR = generateFolderName();
+    
+    const generator = new Generator(path.normalize('./'), OUTPUT_DIR, { forceWrite: true });
+    await generator.generateFromFile(path.resolve('test', 'mocks/smarty-lighting-streetlights.yaml'));
+
+    const expectedFiles = [
+      'src/main/java/Application.java',
+      'src/main/java/DimLightPayload.java',
+      'src/main/java/LightMeasuredPayload.java',
+      'src/main/java/SentAt.java',
+      'src/main/java/SubObject.java',
+      'src/main/java/TurnOnOffPayload.java'
+    ];
+    await assertExpectedFiles(OUTPUT_DIR, expectedFiles);
   });
 });

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -6,7 +6,6 @@ const crypto = require('crypto');
 const MAIN_TEST_RESULT_PATH = path.join('test', 'temp', 'integrationTestResult');
 
 describe('template integration tests using the generator', () => {
-
   jest.setTimeout(30000);
 
   const generateFolderName = () => {
@@ -19,7 +18,7 @@ describe('template integration tests using the generator', () => {
       const file = await readFile(path.join(outputDirectory, expectedFiles[index]), 'utf8');
       expect(file).toMatchSnapshot();
     }
-  }
+  };
 
   it('should generate application files using the solace binder', async () => {
     const OUTPUT_DIR = generateFolderName();
@@ -163,7 +162,7 @@ describe('template integration tests using the generator', () => {
       'src/main/java/LightMeasuredPayload.java',
       'src/main/java/SentAt.java',
       'src/main/java/TurnOnOffPayload.java',
-	  'src/main/java/SubObject.java'
+      'src/main/java/SubObject.java'
     ];
     await assertExpectedFiles(OUTPUT_DIR, expectedFiles);
   });

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const Generator = require('@asyncapi/generator');
-const { readFile } = require('fs').promises;
+const { readFile, readdir } = require('fs').promises;
 const crypto = require('crypto');
 
 const MAIN_TEST_RESULT_PATH = path.join('test', 'temp', 'integrationTestResult');
@@ -143,6 +143,8 @@ describe('template integration tests using the generator', () => {
     const generator = new Generator(path.normalize('./'), OUTPUT_DIR, { forceWrite: true });
     await generator.generateFromFile(path.resolve('test', 'mocks/nested-arrays.yaml'));
 
+	// TODO: The All args constructor is broken for arrays
+
     const expectedFiles = [
       'src/main/java/Application.java',
       'src/main/java/Dossier.java',
@@ -162,8 +164,8 @@ describe('template integration tests using the generator', () => {
       'src/main/java/DimLightPayload.java',
       'src/main/java/LightMeasuredPayload.java',
       'src/main/java/SentAt.java',
-      'src/main/java/SubObject.java',
-      'src/main/java/TurnOnOffPayload.java'
+      'src/main/java/TurnOnOffPayload.java',
+	  'src/main/java/SubObject.java'
     ];
     await assertExpectedFiles(OUTPUT_DIR, expectedFiles);
   });

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const Generator = require('@asyncapi/generator');
-const { readFile, readdir } = require('fs').promises;
+const { readFile } = require('fs').promises;
 const crypto = require('crypto');
 
 const MAIN_TEST_RESULT_PATH = path.join('test', 'temp', 'integrationTestResult');
@@ -142,8 +142,6 @@ describe('template integration tests using the generator', () => {
     
     const generator = new Generator(path.normalize('./'), OUTPUT_DIR, { forceWrite: true });
     await generator.generateFromFile(path.resolve('test', 'mocks/nested-arrays.yaml'));
-
-	// TODO: The All args constructor is broken for arrays
 
     const expectedFiles = [
       'src/main/java/Application.java',

--- a/test/mocks/nested-arrays.yaml
+++ b/test/mocks/nested-arrays.yaml
@@ -1,0 +1,177 @@
+asyncapi: 2.0.0
+info:
+  description: ''
+  title: IntegrationTask
+  version: 0.0.1
+servers:
+  production:
+    url: tcp://service.messaging.solace.cloud:55555
+    protocol: SMF
+    description: Company Production Broker
+    variables:
+      port:
+        description: Secure connection (TLS) is available through port 55443. Non SSL Compressed protocol is available through port 55003
+        default: '55555'
+        enum:
+          - '55555'
+          - '55443'
+          - '55003'
+components:
+  schemas:
+    Debtor:
+      description: Debtor
+      type: object
+      properties:
+        emails:
+          type: array
+          items:
+            type: object
+            properties:
+              type:
+                type: string
+              email:
+                format: email
+                type: string
+              preferred:
+                type: boolean
+        birthdate:
+          type: string
+        address:
+          type: object
+          properties:
+            country_code:
+              minLength: 2
+              type: string
+              maxLength: 2
+            city:
+              type: string
+            street:
+              type: string
+            postal_code:
+              type: string
+        last_name:
+          type: string
+        phones:
+          type: array
+          items:
+            type: object
+            properties:
+              phone:
+                type: string
+              type:
+                type: string
+              preferred:
+                type: boolean
+        id:
+          type: string
+        first_name:
+          type: string
+        bank_account:
+          type: object
+          properties:
+            IBAN:
+              pattern: '[A-Z]{2}\d{2} ?\d{4} ?\d{4} ?\d{4} ?\d{4} ?[\d]{0,2}'
+              type: string
+            BIC:
+              type: string
+    Dossier:
+      description: Contract info
+      type: object
+      properties:
+        premium:
+          type: number
+        applied_discount:
+          type: number
+        product_id:
+          type: string
+        options:
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+              id:
+                type: string
+        id:
+          type: string
+        client_id:
+          type: string
+  messages:
+    CreateDebtorCommand:
+      payload:
+        $ref: '#/components/schemas/Debtor'
+      description: |-
+        This event contains information about the debtor creation;
+        DebtorId is expected to be null
+      schemaFormat: application/vnd.aai.asyncapi+json;version=2.0.0
+      contentType: application/json
+    DebtorCreatedEvent:
+      payload:
+        $ref: '#/components/schemas/Debtor'
+      description: |-
+        The event that notify of debtor creation.
+        the debtorId is the only information filled in this event
+      schemaFormat: application/vnd.aai.asyncapi+json;version=2.0.0
+      contentType: application/json
+    CreateDossierCommand:
+      payload:
+        $ref: '#/components/schemas/Dossier'
+      description: |-
+        This event contains the informaiton about a dossier creation.
+        The dossier ID is expected to be empty as it's a creation.
+      schemaFormat: application/vnd.aai.asyncapi+json;version=2.0.0
+      contentType: application/json
+    DossierCreatedEvent:
+      payload:
+        $ref: '#/components/schemas/Dossier'
+      description: |-
+        The dossier has been created.
+        The event contains only the Dossier ID
+      schemaFormat: application/vnd.aai.asyncapi+json;version=2.0.0
+      contentType: application/json
+channels:
+  'Company/{customerCompany}/debtor/{debtorId}/Dossier/{dossierId}/created':
+    publish:
+      message:
+        $ref: '#/components/messages/DossierCreatedEvent'
+    parameters:
+      customerCompany:
+        schema:
+          type: string
+      dossierId:
+        schema:
+          type: string
+      debtorId:
+        schema:
+          type: string
+  'Company/{customerCompany}/debtor/{debtorId}/created':
+    publish:
+      message:
+        $ref: '#/components/messages/DebtorCreatedEvent'
+    parameters:
+      customerCompany:
+        schema:
+          type: string
+      debtorId:
+        schema:
+          type: string
+  'Company/{customerCompany}/debtor/create':
+    subscribe:
+      message:
+        $ref: '#/components/messages/CreateDebtorCommand'
+    parameters:
+      customerCompany:
+        schema:
+          type: string
+  'Company/{customerCompany}/debtor/{debtorId}/Dossier/create':
+    subscribe:
+      message:
+        $ref: '#/components/messages/CreateDossierCommand'
+    parameters:
+      customerCompany:
+        schema:
+          type: string
+      debtorId:
+        schema:
+          type: string

--- a/test/mocks/smarty-lighting-streetlights.yaml
+++ b/test/mocks/smarty-lighting-streetlights.yaml
@@ -1,0 +1,216 @@
+asyncapi: '2.0.0'
+info:
+  title: Streetlights API
+  version: '1.0.0'
+  description: |
+    The Smartylighting Streetlights API allows you to remotely manage the city lights.
+
+    ### Check out its awesome features:
+
+    * Turn a specific streetlight on/off 🌃
+    * Dim a specific streetlight 😎
+    * Receive real-time information about environmental lighting conditions 📈
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0
+
+servers:
+  production:
+    url: test.mosquitto.org:{port}
+    protocol: mqtt
+    description: Test broker
+    variables:
+      port:
+        description: Secure connection (TLS) is available through port 8883.
+        default: '1883'
+        enum:
+          - '1883'
+          - '8883'
+    security:
+      - apiKey: []
+      - supportedOauthFlows:
+        - streetlights:on
+        - streetlights:off
+        - streetlights:dim
+      - openIdConnectWellKnown: []
+
+defaultContentType: application/json
+
+channels:
+  smartylighting/streetlights/1/0/event/{streetlightId}/lighting/measured:
+    description: The topic on which measured values may be produced and consumed.
+    parameters:
+      streetlightId:
+        $ref: '#/components/parameters/streetlightId'
+    publish:
+      summary: Inform about environmental lighting conditions of a particular streetlight.
+      operationId: receiveLightMeasurement
+      traits:
+        - $ref: '#/components/operationTraits/kafka'
+      message:
+        $ref: '#/components/messages/lightMeasured'
+
+  smartylighting/streetlights/1/0/action/{streetlightId}/turn/on:
+    parameters:
+      streetlightId:
+        $ref: '#/components/parameters/streetlightId'
+    subscribe:
+      operationId: turnOn
+      traits:
+        - $ref: '#/components/operationTraits/kafka'
+      message:
+        $ref: '#/components/messages/turnOnOff'
+
+  smartylighting/streetlights/1/0/action/{streetlightId}/turn/off:
+    parameters:
+      streetlightId:
+        $ref: '#/components/parameters/streetlightId'
+    subscribe:
+      operationId: turnOff
+      traits:
+        - $ref: '#/components/operationTraits/kafka'
+      message:
+        $ref: '#/components/messages/turnOnOff'
+
+  smartylighting/streetlights/1/0/action/{streetlightId}/dim:
+    parameters:
+      streetlightId:
+        $ref: '#/components/parameters/streetlightId'
+    subscribe:
+      operationId: dimLight
+      traits:
+        - $ref: '#/components/operationTraits/kafka'
+      message:
+        $ref: '#/components/messages/dimLight'
+
+components:
+  messages:
+    lightMeasured:
+      name: lightMeasured
+      title: Light measured
+      summary: Inform about environmental lighting conditions of a particular streetlight.
+      contentType: application/json
+      traits:
+        - $ref: '#/components/messageTraits/commonHeaders'
+      payload:
+        $ref: "#/components/schemas/lightMeasuredPayload"
+    turnOnOff:
+      name: turnOnOff
+      title: Turn on/off
+      summary: Command a particular streetlight to turn the lights on or off.
+      traits:
+        - $ref: '#/components/messageTraits/commonHeaders'
+      payload:
+        $ref: "#/components/schemas/turnOnOffPayload"
+    dimLight:
+      name: dimLight
+      title: Dim light
+      summary: Command a particular streetlight to dim the lights.
+      traits:
+        - $ref: '#/components/messageTraits/commonHeaders'
+      payload:
+        $ref: "#/components/schemas/dimLightPayload"
+
+  schemas:
+    lightMeasuredPayload:
+      type: object
+      properties:
+        lumens:
+          type: integer
+          minimum: 0
+          description: Light intensity measured in lumens.
+        sentAt:
+          $ref: "#/components/schemas/sentAt"
+    turnOnOffPayload:
+      type: object
+      properties:
+        command:
+          type: string
+          enum:
+            - on
+            - off
+          description: Whether to turn on or off the light.
+        sentAt:
+          $ref: "#/components/schemas/sentAt"
+    dimLightPayload:
+      type: object
+      properties:
+        percentage:
+          type: integer
+          description: Percentage to which the light should be dimmed to.
+          minimum: 0
+          maximum: 100
+        sentAt:
+          $ref: "#/components/schemas/sentAt"
+    sentAt:
+      type: object
+      properties:
+        propertySubobject:
+          $ref: "#/components/schemas/subObject"   
+    subObject:
+      type: object
+      properties:
+        propertyA:
+          type: string
+      
+
+  securitySchemes:
+    apiKey:
+      type: apiKey
+      in: user
+      description: Provide your API key as the user and leave the password empty.
+    supportedOauthFlows:
+      type: oauth2
+      description: Flows to support OAuth 2.0
+      flows:
+        implicit:
+          authorizationUrl: 'https://authserver.example/auth'
+          scopes:
+            'streetlights:on': Ability to switch lights on
+            'streetlights:off': Ability to switch lights off
+            'streetlights:dim': Ability to dim the lights
+        password:
+          tokenUrl: 'https://authserver.example/token'
+          scopes:
+            'streetlights:on': Ability to switch lights on
+            'streetlights:off': Ability to switch lights off
+            'streetlights:dim': Ability to dim the lights
+        clientCredentials:
+          tokenUrl: 'https://authserver.example/token'
+          scopes:
+            'streetlights:on': Ability to switch lights on
+            'streetlights:off': Ability to switch lights off
+            'streetlights:dim': Ability to dim the lights
+        authorizationCode:
+          authorizationUrl: 'https://authserver.example/auth'
+          tokenUrl: 'https://authserver.example/token'
+          refreshUrl: 'https://authserver.example/refresh'
+          scopes:
+            'streetlights:on': Ability to switch lights on
+            'streetlights:off': Ability to switch lights off
+            'streetlights:dim': Ability to dim the lights
+    openIdConnectWellKnown:
+      type: openIdConnect
+      openIdConnectUrl: 'https://authserver.example/.well-known'
+
+  parameters:
+    streetlightId:
+      description: The ID of the streetlight.
+      schema:
+        type: string
+
+  messageTraits:
+    commonHeaders:
+      headers:
+        type: object
+        properties:
+          my-app-header:
+            type: integer
+            minimum: 0
+            maximum: 100
+  
+  operationTraits:
+    kafka:
+      bindings:
+        kafka:
+          clientId: my-app-id


### PR DESCRIPTION
**Description**
Resolves an NPE when attempting to use a null modelClass and additionally makes the asyncapi files in the issues usable. As part of making them usable, I changed how inner schemas are identified and created which includes schemas of type array. 

The problem is that we created the modelClass map using the x-schema-parser-id as keys, then as we go through the schema when generating the template, we use the property name instead of the x-schema-parser-id. This leads to returning a null modelClass.
Now, we use the x-parser-schema-id property of the source schema first, then if that turns up nothing, try the property name to get the modelClass. Additionally, the modelClass map is populated with all possible keys for a modelClass. For example, there may be an entry like 'MyAnonSchema' -> ModelClass and another that has the same modelClass copied but for another key like 'anonymous-schema-3' -> ModelClass. This means that we're nearly guaranteed to get a hit when we're getting a modelClass by name.

This also works for $ref. Example:
```
{
    "title": "Myschema",
    "type": "object",
    "properties": {
        "my-prop": {
            "$ref": #/otherSchema
        }
    }
    ...
    "otherSchema": {
        "title": "somethingElse"
    }
}
```
Normally, the schema referred by my-prop will be empty since they’re no data for that ModelClass. Now, the otherSchema ModelClass will be picked up instead because we’ve accounted for this mapping indicated by the $ref. The name ‘my-prop’ isn’t lost though, yes we’re using the OtherSchema class for my-prop, but we’ll use @JsonProperty("my-prop") on OtherSchema otherSchema like we have been doing before. It’s debatable whether we still call the variable name my-prop throughout, ie OtherSchema myProp.

Aside from some spacing adjustments, this is the biggest change in the existing snapshots (two snapshots use this schema, one being the first test, the solace binder test).
solace binder test difference in schema (OLD -> NEW)
![image](https://user-images.githubusercontent.com/32455969/147162743-9714f6b6-8ea7-43a1-bca6-afa454b8ab9e.png)

The all args constructor has been refactored into another partial as well.

**Related issue(s)**
Resolves #194 and resolves #201 which is a duplicate.