### PR TITLE
fix: generation fails when schemas have an $Id field

### DIFF
--- a/hooks/pre-process.js
+++ b/hooks/pre-process.js
@@ -2,6 +2,14 @@ const ApplicationModel = require('../lib/applicationModel.js');
 
 module.exports = {
   'generate:before': generator => {
+    generator.asyncapi.allSchemas().forEach((schema, schemaName) => {
+      // The generator will create file names based on the schema's $id. Instead of guessing what the generator named the file so we can fix it in post,
+      // ... it's easier to process $id here first. Since we don't use it, removing it is easiest.
+      if (schema.$id()) {
+        delete schema._json.$id;
+      }
+    });
+
     ApplicationModel.asyncapi = generator.asyncapi;
   }
 };

--- a/lib/applicationModel.js
+++ b/lib/applicationModel.js
@@ -22,7 +22,7 @@ class ApplicationModel {
       modelClass = this.modelClassMap[parserSchemaName];
       if (modelClass && _.startsWith(modelClass.getClassName(), 'Anonymous')) {
         // If we translated this schema from the map using an anonymous schema key, we have no idea what the name should be, so we use the one provided directly from the source - not the generator.
-        // If we translated this schema from the map using a known schema (the name of the schema was picked out correctly by the generator), use that name.
+        // Otherwise, if we translated this schema from the map using a known schema (the name of the schema was picked out correctly by the generator), use that name.
         modelClass.setClassName(_.upperFirst(this.isAnonymousSchema(parserSchemaName) ? schemaName : parserSchemaName));
       }
     }
@@ -99,26 +99,15 @@ class ApplicationModel {
 
       ApplicationModel.asyncapi.allSchemas().forEach((schema, schemaName) => {
         debugApplicationModel(`setupModelClassMap anonymous schemas ${schemaName} type ${schema.type()}`);
-        this.checkProperties(schema);
-
-        const allOf = schema.allOf();
-        debugApplicationModel('allOf:');
-        debugApplicationModel(allOf);
-        if (allOf) {
-          allOf.forEach(innerSchema => {
-            const name = innerSchema.ext('x-parser-schema-id');
-            if (this.isAnonymousSchema(name) && innerSchema.type() === 'object') {
-              this.registerSchemaNameToModelClass(innerSchema, schemaName);
-            }
-          });
-        }
+        this.registerSchemasInProperties(schema);
+        this.registerSchemasInAllOf(schema);
       });
       debugApplicationModel('modelClassMap:');
       debugApplicationModel(this.modelClassMap);
     }
   }
 
-  checkProperties(schema) {
+  registerSchemasInProperties(schema) {
     if (!!Object.keys(schema.properties()).length) {
       // Each property name is the name of a schema. It should also have an x-parser-schema-id name. We'll be adding duplicate mappings (two mappings to the same model class) since the anon schemas do have names
       Object.keys(schema.properties()).forEach(property => {
@@ -129,6 +118,20 @@ class ApplicationModel {
           this.modelClassMap[property] = existingModelClass;
         } else {
           this.registerSchemaNameToModelClass(innerSchema, property);
+        }
+      });
+    }
+  }
+
+  registerSchemasInAllOf(schema) {
+    const allOf = schema.allOf();
+    debugApplicationModel('allOf:');
+    debugApplicationModel(allOf);
+    if (allOf) {
+      allOf.forEach(innerSchema => {
+        const name = innerSchema.ext('x-parser-schema-id');
+        if (this.isAnonymousSchema(name) && innerSchema.type() === 'object') {
+          this.registerSchemaNameToModelClass(innerSchema, name);
         }
       });
     }

--- a/test/__snapshots__/integration.test.js.snap
+++ b/test/__snapshots__/integration.test.js.snap
@@ -707,6 +707,134 @@ public class SubObject {
 "
 `;
 
+exports[`template integration tests using the generator should generate code using schemas that have $id set 1`] = `
+"
+import java.util.function.Consumer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+
+@SpringBootApplication
+public class Application {
+
+	private static final Logger logger = LoggerFactory.getLogger(Application.class);
+
+	public static void main(String[] args) {
+		SpringApplication.run(Application.class);
+	}
+
+	@Bean
+	public Consumer<DefaultMessageSchema> acmeRideshareRideRequested001Consumer() {
+		return data -> {
+			// Add business logic here.	
+			logger.info(data.toString());
+		};
+	}
+
+}
+"
+`;
+
+exports[`template integration tests using the generator should generate code using schemas that have $id set 2`] = `
+"
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class DefaultMessageSchema {
+
+	public DefaultMessageSchema () {
+	}
+
+	public DefaultMessageSchema (
+		java.math.BigDecimal avgMeterReading, 
+		Integer windowDurationSec, 
+		java.math.BigDecimal avgPassengerCount, 
+		Integer windowRideCount, 
+		String timestamp) {
+		this.avgMeterReading = avgMeterReading;
+		this.windowDurationSec = windowDurationSec;
+		this.avgPassengerCount = avgPassengerCount;
+		this.windowRideCount = windowRideCount;
+		this.timestamp = timestamp;
+	}
+
+	@JsonProperty(\\"avg_meter_reading\\")
+	private java.math.BigDecimal avgMeterReading;
+	@JsonProperty(\\"window_duration_sec\\")
+	private Integer windowDurationSec;
+	@JsonProperty(\\"avg_passenger_count\\")
+	private java.math.BigDecimal avgPassengerCount;
+	@JsonProperty(\\"window_ride_count\\")
+	private Integer windowRideCount;
+	private String timestamp;
+	public java.math.BigDecimal getAvgMeterReading() {
+		return avgMeterReading;
+	}
+
+	public DefaultMessageSchema setAvgMeterReading(java.math.BigDecimal avgMeterReading) {
+		this.avgMeterReading = avgMeterReading;
+		return this;
+	}
+
+
+	public Integer getWindowDurationSec() {
+		return windowDurationSec;
+	}
+
+	public DefaultMessageSchema setWindowDurationSec(Integer windowDurationSec) {
+		this.windowDurationSec = windowDurationSec;
+		return this;
+	}
+
+
+	public java.math.BigDecimal getAvgPassengerCount() {
+		return avgPassengerCount;
+	}
+
+	public DefaultMessageSchema setAvgPassengerCount(java.math.BigDecimal avgPassengerCount) {
+		this.avgPassengerCount = avgPassengerCount;
+		return this;
+	}
+
+
+	public Integer getWindowRideCount() {
+		return windowRideCount;
+	}
+
+	public DefaultMessageSchema setWindowRideCount(Integer windowRideCount) {
+		this.windowRideCount = windowRideCount;
+		return this;
+	}
+
+
+	public String getTimestamp() {
+		return timestamp;
+	}
+
+	public DefaultMessageSchema setTimestamp(String timestamp) {
+		this.timestamp = timestamp;
+		return this;
+	}
+
+	public String toString() {
+		return \\"DefaultMessageSchema [\\"
+		+ \\" avgMeterReading: \\" + avgMeterReading
+		+ \\" windowDurationSec: \\" + windowDurationSec
+		+ \\" avgPassengerCount: \\" + avgPassengerCount
+		+ \\" windowRideCount: \\" + windowRideCount
+		+ \\" timestamp: \\" + timestamp
+		+ \\" ]\\";
+	}
+}
+"
+`;
+
 exports[`template integration tests using the generator should generate extra config when using the paramatersToHeaders parameter 1`] = `
 "package com.acme;
 

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -6,7 +6,7 @@ const crypto = require('crypto');
 const MAIN_TEST_RESULT_PATH = path.join('test', 'temp', 'integrationTestResult');
 
 describe('template integration tests using the generator', () => {
-  jest.setTimeout(999000);
+  jest.setTimeout(30000);
 
   const generateFolderName = () => {
     // you always want to generate to new directory to make sure test runs in clear environment

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -6,7 +6,7 @@ const crypto = require('crypto');
 const MAIN_TEST_RESULT_PATH = path.join('test', 'temp', 'integrationTestResult');
 
 describe('template integration tests using the generator', () => {
-  jest.setTimeout(30000);
+  jest.setTimeout(999000);
 
   const generateFolderName = () => {
     // you always want to generate to new directory to make sure test runs in clear environment
@@ -163,6 +163,19 @@ describe('template integration tests using the generator', () => {
       'src/main/java/SentAt.java',
       'src/main/java/TurnOnOffPayload.java',
       'src/main/java/SubObject.java'
+    ];
+    await assertExpectedFiles(OUTPUT_DIR, expectedFiles);
+  });
+
+  it('should generate code using schemas that have $id set', async () => {
+    const OUTPUT_DIR = generateFolderName();
+    
+    const generator = new Generator(path.normalize('./'), OUTPUT_DIR, { forceWrite: true });
+    await generator.generateFromFile(path.resolve('test', 'mocks/using-$id-field.yaml'));
+
+    const expectedFiles = [
+      'src/main/java/Application.java',
+      'src/main/java/DefaultMessageSchema.java'
     ];
     await assertExpectedFiles(OUTPUT_DIR, expectedFiles);
   });

--- a/test/mocks/using-$id-field.yaml
+++ b/test/mocks/using-$id-field.yaml
@@ -1,0 +1,86 @@
+---
+components:
+  schemas:
+    default message schema:
+      default: {}
+      $schema: "http://json-schema.org/draft-07/schema"
+      $id: "http://example.com/example.json"
+      examples:
+      - avg_meter_reading: 21.615217
+        window_duration_sec: 300
+        avg_passenger_count: 1.5
+        window_ride_count: 5
+        timestamp: "2020-06-04T20:09:59.99832-04:00"
+      description: "default placeholder for schema"
+      additionalProperties: true
+      type: "object"
+      title: "The root schema"
+      required:
+      - "timestamp"
+      - "avg_meter_reading"
+      - "avg_passenger_count"
+      - "window_duration_sec"
+      - "window_ride_count"
+      properties:
+        avg_meter_reading:
+          default: 0
+          examples:
+          - 21.615217
+          description: "An explanation about the purpose of this instance."
+          type: "number"
+          title: "The avg_meter_reading schema"
+          $id: "#/properties/avg_meter_reading"
+        window_duration_sec:
+          default: 0
+          examples:
+          - 300
+          description: "An explanation about the purpose of this instance."
+          type: "integer"
+          title: "The window_duration_sec schema"
+          $id: "#/properties/window_duration_sec"
+        avg_passenger_count:
+          default: 0
+          examples:
+          - 1.5
+          description: "An explanation about the purpose of this instance."
+          type: "number"
+          title: "The avg_passenger_count schema"
+          $id: "#/properties/avg_passenger_count"
+        window_ride_count:
+          default: 0
+          examples:
+          - 5
+          description: "An explanation about the purpose of this instance."
+          type: "integer"
+          title: "The window_ride_count schema"
+          $id: "#/properties/window_ride_count"
+        timestamp:
+          default: ""
+          examples:
+          - "2020-06-04T20:09:59.99832-04:00"
+          description: "An explanation about the purpose of this instance."
+          type: "string"
+          title: "The timestamp schema"
+          $id: "#/properties/timestamp"
+  messages:
+    ride requested 2:
+      payload:
+        $ref: "#/components/schemas/default message schema"
+      schemaFormat: "application/vnd.aai.asyncapi+json;version=2.0.0"
+      contentType: "application/json"
+servers:
+  production:
+    protocol: "smf"
+    url: "my_server"
+channels:
+  acme/rideshare/ride/requested/0.0.1:
+    publish:
+      message:
+        $ref: "#/components/messages/ride requested 2"
+asyncapi: "2.0.0"
+info:
+  x-generated-time: "2021-09-29 13:44 UTC"
+  description: "test\n\n---\n\ntest"
+  title: "mh acme 2"
+  x-view: "provider"
+  version: "1"


### PR DESCRIPTION
**Problem**
The generator generates file names using the $id value as its preferred option. This causes problems with code generation because the IDs typically contain unwanted characters that may change the path of the files or aren't allowed by the OS.
Since the x-schema-parser-id is what we tend to use to identify schemas and the name of the schema is either the parser ID or the json/yaml key of the schema, we would run into unnecessary confusion.
In short, when a schema with $id is present, the generator tries to name the file the $id value, which is identified by a different, independent x-schema-parser-id typically derived from a sometimes different key name.
We already prefer to use the x-schema-parser-id to identify schemas but sometimes use the key name to help, so the $id was causing us to not write the modelClass correctly.

**Solution**
The implemented fix is to remove the $id from the document before feeding it to the generator as part of the generate:before hook since $id isn't being used in the code generator anyway.


Theory
**If $id would need to remain intact...** 
...the fix needs to be much more complicated. There are two big problems.

**Problem 1:** The code generator doesn't and shouldn't know how the generator names files. The implementation shouldn't matter, but since the generator favours naming files based on $id, it'll be common for the name to be manipulated to become valid. For example, changing 'http://example.com/something' to 'http-example.com-something'. In order to fix this in the generate:after hook, we need to know how the generator comes up with the names which smells bad.
This could also be a problem with the current naming strategy without $id, but it seems very unlikely.

**Problem 2:** Mismatch of x-schema-parser-id, the file name generated from $id, and the key name. There will be times when we need to translate the $id into the schema's x-schema-parser-id so that we know which schema we're talking about. We can do it early once, for now, but may to do it in other places later on.
For example...
```
validateSchemaName(schema, schemaName) {
	// The generator will say the name of the schema is the $id which is inconvenient for us.
	// In addition to making the className correct, we must make the key in the modelClassMap is easily known when we retrieve the modelClass. x-schema-parser-id is the best candidate key.
	if (schema.$id() == schemaName) {
		return schema.ext('x-parser-schema-id');
	}
	return schemaName;
}
```

Theoretical solution
- Change $id in generate:before to something file name friendly so the method is known to solve problem 1 and store the original $id value in another variable for use when needed.
- Use validateSchemaName() to translate use of $id to the x-schema-parser-id whenever we add/retrieve the schema to/from the map of schemaName: modelClass to solve problem 2.

**Related issue(s)**
Resolves #208 