### PR TITLE
feat: update support for spec version 2.3.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Note that this template ignores the 'Servers' section of AsyncAPI documents. The
 
 ## Technical requirements
 
-- 1.8.6 =< [Generator](https://github.com/asyncapi/generator/)
+- 1.9.4 =< [Generator](https://github.com/asyncapi/generator/)
 - Generator specific [requirements](https://github.com/asyncapi/generator/#requirements)
 
 ## Specification Conformance

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asyncapi/java-spring-cloud-stream-template",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "description": "Java Spring Cloud Stream template for AsyncAPI generator.",
   "scripts": {
     "release": "semantic-release",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     ]
   },
   "generator": {
-    "generator": ">=1.8.6 <2.0.0",
+    "generator": ">=1.8.6 <=2.3.0",
     "parameters": {
       "actuator": {
         "description": "If present, it adds the dependencies for spring-boot-starter-web, spring-boot-starter-actuator and micrometer-registry-prometheus.",

--- a/test/mocks/animals.yaml
+++ b/test/mocks/animals.yaml
@@ -29,7 +29,7 @@ channels:
         oneOf:
         - $ref: '#/components/messages/CatMessage'
         - $ref: '#/components/messages/DogMessage'
-asyncapi: 2.0.0
+asyncapi: 2.3.0
 info:
   description: Testing oneOf
   title: animals

--- a/test/mocks/solace-test-app.yaml
+++ b/test/mocks/solace-test-app.yaml
@@ -39,7 +39,7 @@ channels:
           enum:
             - POST
             - DELETE
-asyncapi: 2.0.0
+asyncapi: 2.3.0
 info:
   title: solace-test-app
   version: 0.0.1


### PR DESCRIPTION
**Description**

This updates the allowed AsyncAPI files to version 2.3.0. It is not meant to support any new spec features except for the Solace bindings (which have been supported for some time.)

**Related issue(s)**
Fixes #271 

