### PR TITLE
fix: template uses anonymous schema name when object type is unknown

### DIFF
--- a/filters/all.js
+++ b/filters/all.js
@@ -340,12 +340,7 @@ function fixType([name, javaName, property]) {
       // Picking a type for the user may be difficult - especially since the first avro union value must be the default value which is normally of type null.
       typeName = 'Object';
     } else {
-      // We could assume it's an object and the class name derrived from the model class mapping is correct
-	  // typeName = javaName;
-
-      if (!typeName) {
-        throw new Error(`Can't determine the type of property ${  name  }`);
-      }
+      throw new Error(`Can't determine the type of property ${  name  }`);
     }
   } else if (type === 'array') {
     if (!property.items()) {

--- a/filters/all.js
+++ b/filters/all.js
@@ -340,11 +340,11 @@ function fixType([name, javaName, property]) {
       // Picking a type for the user may be difficult - especially since the first avro union value must be the default value which is normally of type null.
       typeName = 'Object';
     } else {
-      // check to see if it's a ref to another schema.
-      typeName = property.ext('x-parser-schema-id');
+      // We could assume it's an object and the class name derrived from the model class mapping is correct
+	  // typeName = javaName;
 
       if (!typeName) {
-        throw new Error(`Can't determine the type of property ${  name}`);
+        throw new Error(`Can't determine the type of property ${  name  }`);
       }
     }
   } else if (type === 'array') {

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -240,4 +240,5 @@ describe('template integration tests using the generator', () => {
     ];
     await assertExpectedFiles(validatedFiles);
   });
+
 });

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -240,5 +240,4 @@ describe('template integration tests using the generator', () => {
     ];
     await assertExpectedFiles(validatedFiles);
   });
-
 });


### PR DESCRIPTION
**Description**

Throw error when schema type is unknown instead of setting to the x-schema-parser-id.

This doesn't break the functionality of setting $ref for a referenced schema (that doesn't have type set)
Given
```
"components": {
    "schemas": {
      "FelineSchema": {
        "type": "object",
        "properties": {
          "canMeow": {
            "$ref": "#/components/schemas/CatSchema"
          }
        }
      },
      "CatSchema": {
        "type": "object",
        "properties": {
          "meow": {
            "type": "integer"
          }
        }
      }
    }
  }
```
'canMeow' doesn't have a type but that's okay because in the modelClass mapping, we said that canMeow maps to the CatSchema object which does have a type so we get the following correct result with CatSchema defined in its own file.
```
@JsonInclude(JsonInclude.Include.NON_NULL)
public class FelineSchema {

	public FelineSchema () {
	}

	public FelineSchema (
		CatSchema catSchema) {
		this.catSchema = catSchema;
	}

	@JsonProperty("canMeow")
	private CatSchema catSchema;
	
	public CatSchema getCatSchema() {
		return catSchema;
	}

	public FelineSchema setCatSchema(CatSchema catSchema) {
		this.catSchema = catSchema;
		return this;
	}

	public String toString() {
		return "FelineSchema ["
		+ " catSchema: " + catSchema
		+ " ]";
	}
}
```

**Related issue(s)**
Resolves #288 